### PR TITLE
add version number to platforms.json

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -1,4 +1,5 @@
 {
+    "__fileversion":"3.8.0"
     "platforms": [
         {
             "name": "3do",


### PR DESCRIPTION
For RetroPie script

I have no idea if what I'm doing is correct but this *seems* to work alright here, and then the RP script can read this and decide either to backup and overwrite the file, or just `copyDefaultConfig` on it.

I see the repo is at 3.8.1 but I called this 3.8.0 since that's when this file version was introduced. Doesn't have to update every time the repo does, only when the file changes significantly enough to need replaced.