### PR TITLE
Bugfix/windows build support whitespace in path

### DIFF
--- a/win32/README.md
+++ b/win32/README.md
@@ -23,7 +23,7 @@ Nothing I (Gemba) have to add here.
 - Get "Git for Windows" and install with default values
 - Checkout Skyscraper from [1] into a folder. This folder is
   `<skyscraper_git>` in following.
-- Get Qt Creator from [2] (use Chrome/Edge as in FF the links may not work):
+- Get Qt Creator from [2]:
   Follow link "Download the Qt Online Installer", then select "Offline installer".
 - In Installer: Select _Developer and Designer Tools_, expand subtree and
   select _MinGW 7.3.0 64-Bit_, choose also from _Qt/Qt<version>/MinGW 7.3.0 64-Bit_
@@ -43,13 +43,13 @@ Nothing I (Gemba) have to add here.
 
 1. Open a command prompt
 2. Change to `<skyscraper_git>\build\release`
-3. Run `.\skyscraper --help`
+3. Run `.\Skyscraper.exe --help`
 4. Check that the available platforms are listed and are not empty
 5. Smile :)
 
 # Notes
 
-- Tested with Qt 5.12.12 Open Source Ed. on Windows 10 (64Bit)
+- Tested with Qt 5.12.12 Open Source Ed., MinGW 7.3.0 64-bit, Qt Creator 12.0.1 (Community) on Windows 10 and 11 Pro (64Bit)
 - Home Path is `%USERPROFILE%/.skyscraper` (instead of `/home/pi/.skyscraper`)
 
 # Refs

--- a/win32/skyscraper.pro
+++ b/win32/skyscraper.pro
@@ -36,9 +36,9 @@ win32 {
     $$escape_expand(\\n\\t)
 
   # create mandatory folders and deploy mandatory files
-  QMAKE_POST_LINK += powershell -Command 'md -Force $$shell_quote($$shell_path($$(USERPROFILE)/RetroPie/roms))' > NUL &
+  QMAKE_POST_LINK += powershell -Command "md -Force '$$shell_path($$(USERPROFILE)/RetroPie/roms)'" > NUL &
   QMAKE_POST_LINK += powershell -NoProfile -NoLogo -NonInteractive -ExecutionPolicy Bypass \
-    -File $${PWD}/deploy_mandatory_files.ps1 \
+    -File $$shell_quote($$shell_path($${PWD}/deploy_mandatory_files.ps1)) \
     $$shell_quote($${PWD}/..) $$shell_quote($$shell_path($$(USERPROFILE)/.skyscraper)) \
     $$escape_expand(\\n\\t)
 }


### PR DESCRIPTION
From issue: https://github.com/Gemba/skyscraper/issues/11

If user home or build path contained white space, build was failing on Windows

For some reason, `shell_quote()` qmake function when calling `powershell -Command md -Force ...` was not treated as a single string with white space, but rather multiple strings separated by white space

- Replaced outer single quotes ([which PowerShell interprets enclosed string as _verbatim_](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#single-quoted-strings)) containing command with double-quotes ([which PowerShell interprets enclosed string as _expandable_])(https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#double-quoted-strings)
- Replaced `$$shell_path()` surrounding path in PowerShell 'md` command with single quotes
- Added `qmake` functions for native shell handling of quotes and path for file parameter that was missing it
- Updated docs on building on Windows

Attached are text output and screenshot artifacts of build failure (before) and build success (after)

![build failure](https://github.com/Gemba/skyscraper/assets/6226450/61cc07e8-7eb4-42a3-a55d-c86d0991a297)
[build failure.txt](https://github.com/Gemba/skyscraper/files/13869213/build.failure.txt)
![build success](https://github.com/Gemba/skyscraper/assets/6226450/0f917900-5c57-4e5f-8542-3dd92ef21f6e)
[build success.txt](https://github.com/Gemba/skyscraper/files/13869214/build.success.txt)
