### PR TITLE
Feature - Dev Container Support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+
+# Dev Container Template (https://containers.dev/templates) based on latest Debian "bookworm" release or use vanilla Debian from Docker Hub instead
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+# FROM debian:bookworm
+
+# Update, upgrade, and install necessary packages
+RUN sudo apt update && sudo apt upgrade && sudo apt install -y qtbase5-dev
+
+# Make (compile) and install Skyscraper
+RUN QT_SELECT=5
+# These can not be done in a Dev Container, as workspace doesn't exist until after Docker container is created from image, so commands are unaware of source files. Instead, do in `postCreateCommand` of `devcontainer.json`.
+# RUN qmake && make -j$(nproc) && sudo make install 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:bookworm"
+	"build": {
+		// Path is relative to the `devcontainer.json` file
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Actions that are run after the container is created
+	"postCreateCommand": "qmake && make -j$(nproc) && sudo make install"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ packages
 *-packages
 target
 build
+
+# macOS
+.DS_Store
+
+# VS Code
+*.code-workspace


### PR DESCRIPTION
This adds Dev Container support, with some VS Code-specific extensions defined. Also updated the `.gitignore` to exclude macOS system files, and VS Code workspace files.

This came about for my desire to develop on my Mac, without interfering with my personal machine environment.

---

Here's some background and reasoning:

[Dev Containers](https://containers.dev/) are an IDE-agnostic open specification (originally created by Microsoft/GitHub) that define a container environment to use for development.

This is especially useful for separating development environment configuration from the host system (not polluting `PATH`, environment variables or registry entries, maintaining installation of multiple versions of JDK or Python, etc.) as well as allowing new developers to get up-and-running with all the dependencies that are needed to contribute to the project.

Using one `devcontainer.json` and an optional `Dockerfile`, this is easily accomplished. Any IDE that supports this feature (VS Code, GitHub Codespaces, IntelliJ products, others) will read this file and spin-up the container through a Docker daemon running on Docker Engine, or alternatively, a 3rd-party container engine. The advantage of Dev Containers and `devcontainer.json` over just running a container separately, is that the IDE is aware of the container and connect to it as a remote host in a session for development, and also allows for specification of IDE-specific extensions to be used in that development environment as well. After downloading the initial image and configuring the environment (a couple of minutes), it's lightning fast (a couple of seconds) to start for any development session, even if the `devcontainer.json` or Dockerfile is changed and the container needs to be rebuilt.

In the IDE or through a terminal connection to the container, the project can be built, run, and tested without issue.

**Perhaps best of all, it's just two new files in a hidden directory, which doesn't require anyone to use them if not desired.**

--- 

Caveats:

- While the project can be built, run, and tested in the container, I haven't tested if the resulting binary will "work" outside of the running container in macOS, but is unlikely as it is built by `make`/`qmake` in a Debian container... Until macOS containers are a thing (or able to set a build target via command line when calling `qmake`), this workflow likely will not be possible. This _could_ work if running on a Debian system after building/installing in a Debian container, etc.
- `dependabot.yml` was automatically added, which will keep Dev Container "Features" updated, and can be deleted to opt-out if not desired: https://containers.dev/guide/dependabot