### PR TITLE
Add igdb media retrieval processes & ability to include/exclude media per source/call

### DIFF
--- a/docs/CONFIGINI.md
+++ b/docs/CONFIGINI.md
@@ -85,6 +85,7 @@ This is an alphabetical index of all configuration options including the section
 | [hints](CONFIGINI.md#hints)                                 |    Y     |                |                |               |
 | [importFolder](CONFIGINI.md#importfolder)                   |    Y     |       Y        |                |               |
 | [includeFrom](CONFIGINI.md#includefrom)                     |    Y     |       Y        |                |               |
+| [includeMedia](CONFIGINI.md#includemedia)                   |    Y     |       Y        |                |               |
 | [includePattern](CONFIGINI.md#includepattern)               |    Y     |       Y        |       Y        |               |
 | [inputFolder](CONFIGINI.md#inputfolder)                     |    Y     |       Y        |                |               |
 | [interactive](CONFIGINI.md#interactive)                     |    Y     |       Y        |                |       Y       |
@@ -923,3 +924,18 @@ Allows you to set a platform, which is applied when no command line switch `-p` 
 
 Default value: unset  
 Allowed in sections: `[main]`
+
+---
+
+#### includeMedia
+
+By default, Skyscraper will only include media from scrapers which don't guarantee relevance to the current platform.
+With this setting set to `true` then it will include media for the relevant scrapers.
+With this setting set to `false`, no media will be included.
+
+!!! note
+
+    Setting this to `true` is currently only relevant for the Igdb scraper.
+
+Default value: unset  
+Allowed in sections: `[main]`, `[<SCRAPER>]`

--- a/docs/SCRAPINGMODULES.md
+++ b/docs/SCRAPINGMODULES.md
@@ -123,12 +123,12 @@ Please use this module sparingly. And only ever use it to scrape those last few 
 -   API request limit: _A maximum of 4 requests per seconds is allowed_
 -   Thread limit: _4 (each being limited to 1 request per second)_
 -   Platform support: _[List](https://www.igdb.com/platforms)_
--   Media support: _None_
+-   Media support*: _`cover`, `screenshot`, `marquee`_
 -   Example use:
     -   `Skyscraper -p fba -s igdb <SINGLE FILE TO SCRAPE>`
     -   `Skyscraper -p fba -s igdb --startat <FILE TO START AT> --endat <FILE TO END AT>`
 
-IGDB is a relatively new database on the market. But absolutely not a bad one at that. It has a couple caveats though, as the database doesn't distinguish between platform versions of the same game when it comes to any artwork resources (they are working to implement this at some point). This makes it less usable in a retro game scraping context as many of the games differ drastically visually between the old platforms. For that reason alone, this module will only provide textual data for your roms for the time being.
+IGDB is a relatively new database on the market. But absolutely not a bad one at that. It has a couple caveats though, as the database doesn't distinguish between platform versions of the same game when it comes to any artwork resources (they are working to implement this at some point). This makes it less usable in a retro game scraping context as many of the games differ drastically visually between the old platforms. For that reason alone, this module will only include media if `includeMedia=true` is set in your config.ini for the time being.
 
 It is _required_ to register with the Twitch dev program (IGDB is owned by Twitch) and create a free client-id and secret-key pair for use with Skyscraper. The process of getting this free client-id and secret-key pair is quite easy. Just follow the following steps:
 
@@ -143,6 +143,7 @@ It is _required_ to register with the Twitch dev program (IGDB is owned by Twitc
 ```
 [igdb]
 userCreds="CLIENTID:SECRETKEY"
+includeMedia=false  # set to true to include media for the potentially incorrect platform
 ```
 
 Substitute CLIENTID and SECRETKEY with your own details. And that's it, you should now be able to use the IGDB module.

--- a/src/arcadedb.cpp
+++ b/src/arcadedb.cpp
@@ -42,11 +42,14 @@ ArcadeDB::ArcadeDB(Settings *config, QSharedPointer<NetManager> manager)
     fetchOrder.append(TAGS);
     fetchOrder.append(PLAYERS);
     fetchOrder.append(DESCRIPTION);
-    fetchOrder.append(SCREENSHOT);
-    fetchOrder.append(COVER);
-    fetchOrder.append(WHEEL);
-    fetchOrder.append(MARQUEE);
-    fetchOrder.append(VIDEO);
+    
+    if (config->includeMedia != 2) {
+        fetchOrder.append(SCREENSHOT);
+        fetchOrder.append(COVER);
+        fetchOrder.append(WHEEL);
+        fetchOrder.append(MARQUEE);
+        fetchOrder.append(VIDEO);
+    }
 }
 
 void ArcadeDB::getSearchResults(QList<GameEntry> &gameEntries,

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -154,6 +154,14 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
         "'--cache help' for a full description of all functions.",
         "COMMAND[:OPTIONS]", "");
     QCommandLineOption refreshOption("refresh", "Same as '--cache refresh'.");
+    QCommandLineOption includemediaOption(
+        "includemedia", 
+        "Should Skyscraper include media files?. The default behaviour excludes media "
+        "from sources which are not guaranteed to be the right platform.");
+    QCommandLineOption excludemediaOption(
+        "excludemedia", 
+        "Should Skyscraper exclude all media files?. The default behaviour includes media "
+        "from sources which are guaranteed to be the right platform.");
     QCommandLineOption startatOption(
         "startat",
         "Tells Skyscraper which file to start at. Forces '--refresh' and "
@@ -258,6 +266,7 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
     parser->addOption(eOption);
     parser->addOption(excludefilesOption);
     parser->addOption(excludefromOption);
+    parser->addOption(excludemediaOption);
     parser->addOption(excludepatternOption);
     parser->addOption(flagsOption);
     parser->addOption(fOption);
@@ -266,6 +275,7 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
     parser->addHelpOption();
     parser->addOption(includefilesOption);
     parser->addOption(includefromOption);
+    parser->addOption(includemediaOption);
     parser->addOption(includepatternOption);
     parser->addOption(iOption);
     parser->addOption(langOption);

--- a/src/igdb.cpp
+++ b/src/igdb.cpp
@@ -65,9 +65,11 @@ Igdb::Igdb(Settings *config, QSharedPointer<NetManager> manager)
     fetchOrder.append(PLAYERS);
     fetchOrder.append(TAGS);
     fetchOrder.append(AGES);
-    fetchOrder.append(COVER);       // covers api
-    fetchOrder.append(MARQUEE);     // artworks api
-    fetchOrder.append(SCREENSHOT);  // screenshots api
+    if (config->includeMedia == 1) {
+        fetchOrder.append(COVER);       // covers api
+        fetchOrder.append(MARQUEE);     // artworks api
+        fetchOrder.append(SCREENSHOT);  // screenshots api
+    }
 }
 
 void Igdb::getSearchResults(QList<GameEntry> &gameEntries, QString searchName,

--- a/src/igdb.h
+++ b/src/igdb.h
@@ -54,6 +54,10 @@ private:
     void getPublisher(GameEntry &game) override;
     void getDescription(GameEntry &game) override;
     void getRating(GameEntry &game) override;
+    
+    void getCover(GameEntry &game) override;
+    void getScreenshot(GameEntry &game) override;
+    void getMarquee(GameEntry &game) override;
 
     QList<QString> getSearchNames(const QFileInfo &info) override;
 

--- a/src/importscraper.cpp
+++ b/src/importscraper.cpp
@@ -34,12 +34,14 @@ ImportScraper::ImportScraper(Settings *config,
     fetchOrder.append(TITLE);
     fetchOrder.append(DEVELOPER);
     fetchOrder.append(PUBLISHER);
-    fetchOrder.append(COVER);
-    fetchOrder.append(SCREENSHOT);
-    fetchOrder.append(WHEEL);
-    fetchOrder.append(MARQUEE);
-    fetchOrder.append(TEXTURE);
-    fetchOrder.append(VIDEO);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(COVER);
+        fetchOrder.append(SCREENSHOT);
+        fetchOrder.append(WHEEL);
+        fetchOrder.append(MARQUEE);
+        fetchOrder.append(TEXTURE);
+        fetchOrder.append(VIDEO);
+    }
     fetchOrder.append(RELEASEDATE);
     fetchOrder.append(TAGS);
     fetchOrder.append(PLAYERS);

--- a/src/mobygames.cpp
+++ b/src/mobygames.cpp
@@ -53,8 +53,10 @@ MobyGames::MobyGames(Settings *config, QSharedPointer<NetManager> manager)
     fetchOrder.append(DESCRIPTION);
     fetchOrder.append(AGES);
     fetchOrder.append(RATING);
-    fetchOrder.append(COVER);
-    fetchOrder.append(SCREENSHOT);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(COVER);
+        fetchOrder.append(SCREENSHOT);
+    }
 }
 
 void MobyGames::getSearchResults(QList<GameEntry> &gameEntries,

--- a/src/openretro.cpp
+++ b/src/openretro.cpp
@@ -80,13 +80,19 @@ OpenRetro::OpenRetro(Settings *config, QSharedPointer<NetManager> manager)
     ratingPre.append("<div class='score'>Score: ");
     ratingPost = "</";
 
-    fetchOrder.append(MARQUEE);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(MARQUEE);
+    }
     fetchOrder.append(DESCRIPTION);
     fetchOrder.append(DEVELOPER);
-    fetchOrder.append(COVER);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(COVER);
+    }
     fetchOrder.append(PLAYERS);
     fetchOrder.append(PUBLISHER);
-    fetchOrder.append(SCREENSHOT);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(SCREENSHOT);
+    }
     fetchOrder.append(TAGS);
     fetchOrder.append(RELEASEDATE);
     fetchOrder.append(RATING);

--- a/src/screenscraper.cpp
+++ b/src/screenscraper.cpp
@@ -56,12 +56,14 @@ ScreenScraper::ScreenScraper(Settings *config,
     fetchOrder.append(DESCRIPTION);
     fetchOrder.append(RELEASEDATE);
     fetchOrder.append(TAGS);
-    fetchOrder.append(SCREENSHOT);
-    fetchOrder.append(COVER);
-    fetchOrder.append(WHEEL);
-    fetchOrder.append(MARQUEE);
-    fetchOrder.append(TEXTURE);
-    fetchOrder.append(VIDEO);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(SCREENSHOT);
+        fetchOrder.append(COVER);
+        fetchOrder.append(WHEEL);
+        fetchOrder.append(MARQUEE);
+        fetchOrder.append(TEXTURE);
+        fetchOrder.append(VIDEO);
+    }
 }
 
 void ScreenScraper::getSearchResults(QList<GameEntry> &gameEntries,

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -324,6 +324,10 @@ void RuntimeCfg::applyConfigIni(CfgType type, QSettings *settings,
                 config->hints = v;
                 continue;
             }
+            if (k == "includeMedia") {
+                config->includeMedia = v == true ? 1 : 2;
+                continue;
+            }
             if (k == "interactive") {
                 config->interactive = v;
                 continue;
@@ -543,6 +547,12 @@ void RuntimeCfg::applyCli(bool &inputFolderSet, bool &gameListFolderSet,
     }
     if (parser->isSet("endat")) {
         config->endAt = parser->value("endat");
+    }
+    if (parser->isSet("includemedia")) {
+        config->includeMedia = 1;
+    }
+    if (parser->isSet("excludemedia")) {
+        config->includeMedia = 2;
     }
     // This option is DEPRECATED, use includepattern
     if (parser->isSet("includefiles")) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -73,6 +73,7 @@ struct Settings {
     int maxLength = 2500;
     bool brackets = true;
     bool refresh = false;
+    int includeMedia = 0; // 0 = default, 1 = yes, 2 = no
     QString cacheOptions = "";
     bool cacheResize = true;
     int jpgQuality = 95;
@@ -201,6 +202,7 @@ private:
         {"importFolder",          QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM                                        )},
         {"includeFiles",          QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"includeFrom",           QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM                                        )},
+        {"includeMedia",          QPair<QString, int>("bool", CfgType::MAIN |                                         CfgType::SCRAPER )},
         {"includePattern",        QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"inputFolder",           QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM                                        )},
         {"interactive",           QPair<QString, int>("bool", CfgType::MAIN | CfgType::PLATFORM |                     CfgType::SCRAPER )},

--- a/src/thegamesdb.cpp
+++ b/src/thegamesdb.cpp
@@ -47,10 +47,12 @@ TheGamesDb::TheGamesDb(Settings *config, QSharedPointer<NetManager> manager)
     fetchOrder.append(DEVELOPER);
     fetchOrder.append(PUBLISHER);
     // fetchOrder.append(RATING);
-    fetchOrder.append(COVER);
-    fetchOrder.append(SCREENSHOT);
-    fetchOrder.append(WHEEL);
-    fetchOrder.append(MARQUEE);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(COVER);
+        fetchOrder.append(SCREENSHOT);
+        fetchOrder.append(WHEEL);
+        fetchOrder.append(MARQUEE);
+    }
 }
 
 void TheGamesDb::getSearchResults(QList<GameEntry> &gameEntries,

--- a/src/worldofspectrum.cpp
+++ b/src/worldofspectrum.cpp
@@ -64,8 +64,10 @@ WorldOfSpectrum::WorldOfSpectrum(Settings *config,
     coverPost = "\" TARGET";
     screenshotPost = "\" BORDER";
 
-    fetchOrder.append(COVER);
-    fetchOrder.append(SCREENSHOT);
+    if (config->includeMedia != 2) {
+        fetchOrder.append(COVER);
+        fetchOrder.append(SCREENSHOT);
+    }
     fetchOrder.append(RELEASEDATE);
     fetchOrder.append(PUBLISHER);
     fetchOrder.append(DEVELOPER);


### PR DESCRIPTION
Skyscraper previously just did not get any media from Igdb at all, even though it got the URLs already. According to the documentation, this is due to a complaint about the quality of the media relating to the titles (different platforms having drastically different art).
While this might be true, it doesn't make sense to remove the ability to retrieve media if someone _wants_ to.

I've added the relevant code paths in Igdb.cpp to retrieve the media from the Igdb api.

Cover maps to the `covers` api
Screenshot maps to the `screenshots` api
Marquee maps to the `artworks` api (as far as I can tell)

When getting the url, it changes the size provided from the API to the original uploaded size: `t_original`.

Now in the vein of keeping this **backwards-compatible**, I've made it so you only get media from Igdb if you've explicitly asked for it.

Config.ini's `[main]` section and `[scraper]` sections now support `includeMedia`. By default, this is `unset`, which uses the existing default behaviour. If set to `true`, it forces all/a specific scraper to get media if possible. If set to `false`, it will never retrieve media at all.
This is complemented by 2 new cli switches: `--includemedia` and `--excludemedia`.

With these changes it's now possible to, for example, retrieve all game data from ScreenScraper or MobyGames, which are heavily rate-limited APIs, without getting any media. In theory a user could then retrieve media only from faster sources.