### PR TITLE
Swap thumbnail and image in ES gamelist XML

### DIFF
--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -272,8 +272,8 @@ QString EmulationStation::createXml(GameEntry &entry) {
     l.append(elem("path", entry.path, addEmptyElem));
     l.append(elem("name", entry.title, addEmptyElem));
 
-    l.append(elem("thumbnail", entry.coverFile, addEmptyElem, true));
-    l.append(elem("image", entry.screenshotFile, addEmptyElem, true));
+    l.append(elem("thumbnail", entry.screenshotFile, addEmptyElem, true));
+    l.append(elem("image", entry.coverFile, addEmptyElem, true));
     l.append(elem("marquee", entry.marqueeFile, addEmptyElem, true));
     l.append(elem("texture", entry.textureFile, addEmptyElem, true));
 


### PR DESCRIPTION
When EmulationStation is in video mode but a particular game doesn't have a video available, it [uses the thumbnail in place of a video](https://github.com/RetroPie/EmulationStation/blob/a5cc5cea9c3d7a4b0f0f499b6d5162702d2d62f0/es-app/src/views/gamelist/VideoGameListView.cpp#L268). Skyscraper currently puts the path to the cover/box art in the `<thumbnail>` element in the EmulationStation gamelist. This is particularly an issue with themes that display cover art and a video or screenshot simultaneously, and when using [`artwork.xml.example2`](https://github.com/Gemba/skyscraper/blob/master/artwork.xml.example2) to output raw media assets (games that don't have videos will show the cover art twice, instead of showing a screenshot in place of the video).

This change swaps where Skyscraper puts cover and screenshot paths in the gamelist XML, so EmulationStation shows a screenshot (instead of cover/box art) when a video isn't available.