### PR TITLE
Feature - "Direct match" scraper module support for `aliasMap.csv`

### DIFF
--- a/aliasMap.csv
+++ b/aliasMap.csv
@@ -3,13 +3,13 @@
 #
 # Note 1! This file is global and will be used when scraping ANY platform.
 #
-# Note 2! All bracket info in these titles are ignored. This is a search name alias
-#         NOT a title alias. It merely provides a different base name for Skyscraper
-#         when it creates the search query. It is meant to help scrape files that have
-#         abstract file names where the search based scraping modules have a hard time
-#         finding good results.
+# Note 2! All bracket info in the search name alias is ignored.
+#         It merely provides a different base name for Skyscraper when it creates
+#         the search query. It is meant to help scrape files that have abstract filenames
+#         where the search-based scraping modules have a hard time finding good 
+#         results, or you know the specific entry in direct-match scraping modules.
 #         If you wish to keep or add brackets to a title you can still do so by adding
-#         them to the actual file instead.
+#         them to the actual filename instead.
 #
 # Format (without the quotes):
 # "Rom Filename (Europe);Use This Name Instead"

--- a/src/abstractscraper.cpp
+++ b/src/abstractscraper.cpp
@@ -457,41 +457,51 @@ bool AbstractScraper::checkNom(const QString nom) {
     return false;
 }
 
-QList<QString> AbstractScraper::getSearchNames(const QFileInfo &info) {
-    QString baseName = info.completeBaseName();
+QList<QString> AbstractScraper::getSearchNames(const QFileInfo &info, QString &debug) {
+    QString baseName = info.baseName();
+    QList<QString> searchNames;
+    QString searchName = baseName;
+
+    debug.append("Base name: '" + baseName + "'\n");
 
     if (config->scraper != "import") {
         if (!config->aliasMap[baseName].isEmpty()) {
-            baseName = config->aliasMap[baseName];
+            debug.append("'aliasMap.csv' entry found\n");
+            QString aliasName = config->aliasMap[baseName];
+            debug.append("Alias name: '" + aliasName + "'\n");
+            searchName = aliasName;
         } else if (info.suffix() == "lha") {
             QString nameWithSpaces = config->whdLoadMap[baseName].first;
             if (nameWithSpaces.isEmpty()) {
-                baseName = NameTools::getNameWithSpaces(baseName);
+                searchName = NameTools::getNameWithSpaces(baseName);
             } else {
-                baseName = nameWithSpaces;
+                debug.append("'whdload_db.xml' entry found\n");
+                searchName = nameWithSpaces;
+                debug.append("Entry name: '" + searchName + "'\n");
             }
         } else if (config->platform == "scummvm") {
-            baseName = NameTools::getScummName(baseName, config->scummIni);
+            searchName = NameTools::getScummName(baseName, config->scummIni);
         } else if ((config->platform == "neogeo" ||
                     config->platform == "arcade" ||
                     config->platform == "mame-advmame" ||
                     config->platform == "mame-libretro" ||
                     config->platform == "mame-mame4all" ||
                     config->platform == "fba") &&
-                   !config->mameMap[baseName].isEmpty()) {
-            baseName = config->mameMap[baseName];
+                    !config->mameMap[baseName].isEmpty()) {
+            debug.append("'mameMap.csv' entry found\n");
+            searchName = config->mameMap[baseName];
+            debug.append("Entry name: '" + searchName + "'\n");
         }
     }
 
-    QList<QString> searchNames;
-
-    if (baseName.isEmpty())
+    if (searchName.isEmpty())
         return searchNames;
 
-    searchNames.append(NameTools::getUrlQueryName(baseName));
+    searchNames.append(NameTools::getUrlQueryName(searchName));
 
-    if (baseName.contains(":") || baseName.contains(" - ")) {
-        QString noSubtitle = baseName.left(baseName.indexOf(":")).simplified();
+    // If search name has a subtitle, also search without subtitle
+    if (searchName.contains(":") || searchName.contains(" - ")) {
+        QString noSubtitle = searchName.left(searchName.indexOf(":")).simplified();
         noSubtitle = noSubtitle.left(noSubtitle.indexOf(" - ")).simplified();
         // Only add if longer than 3. We don't want to search for "the" for
         // instance
@@ -499,18 +509,20 @@ QList<QString> AbstractScraper::getSearchNames(const QFileInfo &info) {
             searchNames.append(NameTools::getUrlQueryName(noSubtitle));
     }
 
-    if (NameTools::hasRomanNumeral(baseName) ||
-        NameTools::hasIntegerNumeral(baseName)) {
-        if (NameTools::hasRomanNumeral(baseName)) {
-            baseName = NameTools::convertToIntegerNumeral(baseName);
-        } else if (NameTools::hasIntegerNumeral(baseName)) {
-            baseName = NameTools::convertToRomanNumeral(baseName);
+    // If the search name has a Roman numeral, also search for an integer numeral version, vice-versa
+    if (NameTools::hasRomanNumeral(searchName) ||
+        NameTools::hasIntegerNumeral(searchName)) {
+        if (NameTools::hasRomanNumeral(searchName)) {
+            searchName = NameTools::convertToIntegerNumeral(searchName);
+        } else if (NameTools::hasIntegerNumeral(searchName)) {
+            searchName = NameTools::convertToRomanNumeral(searchName);
         }
-        searchNames.append(NameTools::getUrlQueryName(baseName));
+        searchNames.append(NameTools::getUrlQueryName(searchName));
 
-        if (baseName.contains(":") || baseName.contains(" - ")) {
+        // If search name has a subtitle, also search without subtitle
+        if (searchName.contains(":") || searchName.contains(" - ")) {
             QString noSubtitle =
-                baseName.left(baseName.indexOf(":")).simplified();
+                searchName.left(searchName.indexOf(":")).simplified();
             noSubtitle =
                 noSubtitle.left(noSubtitle.indexOf(" - ")).simplified();
             // Only add if longer than 3. We don't want to search for "the" for
@@ -524,20 +536,21 @@ QList<QString> AbstractScraper::getSearchNames(const QFileInfo &info) {
 }
 
 QString AbstractScraper::getCompareTitle(QFileInfo info) {
-    QString baseName = info.completeBaseName();
+    QString baseName = info.baseName();
+    QString compareTitle;
 
     if (config->scraper != "import") {
         if (!config->aliasMap[baseName].isEmpty()) {
-            baseName = config->aliasMap[baseName];
+            compareTitle = config->aliasMap[baseName];
         } else if (info.suffix() == "lha") {
             QString nameWithSpaces = config->whdLoadMap[baseName].first;
             if (nameWithSpaces.isEmpty()) {
-                baseName = NameTools::getNameWithSpaces(baseName);
+                compareTitle = NameTools::getNameWithSpaces(baseName);
             } else {
-                baseName = nameWithSpaces;
+                compareTitle = nameWithSpaces;
             }
         } else if (config->platform == "scummvm") {
-            baseName = NameTools::getScummName(baseName, config->scummIni);
+            compareTitle = NameTools::getScummName(baseName, config->scummIni);
         } else if ((config->platform == "neogeo" ||
                     config->platform == "arcade" ||
                     config->platform == "mame-advmame" ||
@@ -545,34 +558,34 @@ QString AbstractScraper::getCompareTitle(QFileInfo info) {
                     config->platform == "mame-mame4all" ||
                     config->platform == "fba") &&
                    !config->mameMap[baseName].isEmpty()) {
-            baseName = config->mameMap[baseName];
+            compareTitle = config->mameMap[baseName];
         }
     }
 
     // Now create actual compareTitle
-    baseName = baseName.replace("_", " ")
-                   .left(baseName.indexOf("("))
-                   .left(baseName.indexOf("["))
+    compareTitle = compareTitle.replace("_", " ")
+                   .left(compareTitle.indexOf("("))
+                   .left(compareTitle.indexOf("["))
                    .simplified();
 
     QRegularExpressionMatch match;
 
     // Always move ", The" to the beginning of the name
-    match = QRegularExpression(", [Tt]he").match(baseName);
+    match = QRegularExpression(", [Tt]he").match(compareTitle);
     if (match.hasMatch()) {
-        baseName = baseName.replace(match.captured(0), "")
+        compareTitle = compareTitle.replace(match.captured(0), "")
                        .prepend(match.captured(0).right(3) + " ");
     }
 
     // Remove "vX.XXX" versioning string if one is found
     match = QRegularExpression(
                 " v[.]{0,1}([0-9]{1}[0-9]{0,2}[.]{0,1}[0-9]{1,4}|[IVX]{1,5})$")
-                .match(baseName);
+                .match(compareTitle);
     if (match.hasMatch() && match.capturedStart(0) != -1) {
-        baseName = baseName.left(match.capturedStart(0)).simplified();
+        compareTitle = compareTitle.left(match.capturedStart(0)).simplified();
     }
 
-    return baseName;
+    return compareTitle;
 }
 
 void AbstractScraper::runPasses(QList<GameEntry> &gameEntries,
@@ -641,15 +654,19 @@ void AbstractScraper::runPasses(QList<GameEntry> &gameEntries,
     }
 
     QList<QString> searchNames;
-    if (config->searchName.isEmpty()) {
-        searchNames = getSearchNames(info);
-    } else {
+    if (!config->searchName.isEmpty()) {
         // Add the string provided by "--query"
         searchNames.append(config->searchName);
+    } else {
+        searchNames = getSearchNames(info, debug);
     }
 
     if (searchNames.isEmpty()) {
         return;
+    }
+
+    for (int i = 0; i < searchNames.size(); i++) {
+        debug.append(QString("Search name #%1: '" + searchNames.at(i) + "'\n").arg(i+1));
     }
 
     for (int pass = 1; pass <= searchNames.size(); ++pass) {

--- a/src/abstractscraper.h
+++ b/src/abstractscraper.h
@@ -43,7 +43,7 @@ public:
     AbstractScraper(Settings *config, QSharedPointer<NetManager> manager);
     virtual ~AbstractScraper();
     virtual void getGameData(GameEntry &game);
-    virtual QList<QString> getSearchNames(const QFileInfo &info);
+    virtual QList<QString> getSearchNames(const QFileInfo &info, QString &debug);
     virtual QString getCompareTitle(QFileInfo info);
     virtual void runPasses(QList<GameEntry> &gameEntries, const QFileInfo &info,
                            QString &output, QString &debug);

--- a/src/arcadedb.cpp
+++ b/src/arcadedb.cpp
@@ -179,8 +179,20 @@ void ArcadeDB::getVideo(GameEntry &game) {
     }
 }
 
-QList<QString> ArcadeDB::getSearchNames(const QFileInfo &info) {
+QList<QString> ArcadeDB::getSearchNames(const QFileInfo &info, QString &debug) {
+    QString baseName = info.baseName();
     QList<QString> searchNames;
-    searchNames.append(info.baseName());
+    QString searchName = baseName;
+
+    debug.append("Base name: '" + baseName + "'\n");
+
+    if (!config->aliasMap[baseName].isEmpty()) {
+        debug.append("'aliasMap.csv' entry found\n");
+        QString aliasName = config->aliasMap[baseName];
+        debug.append("Alias name: '" + aliasName + "'\n");
+        searchName = aliasName;
+    }
+
+    searchNames.append(searchName);
     return searchNames;
 }

--- a/src/arcadedb.h
+++ b/src/arcadedb.h
@@ -38,7 +38,7 @@ public:
     ArcadeDB(Settings *config, QSharedPointer<NetManager> manager);
 
 private:
-    QList<QString> getSearchNames(const QFileInfo &info) override;
+    QList<QString> getSearchNames(const QFileInfo &info, QString &debug) override;
     void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
                           QString platform) override;
     void getGameData(GameEntry &game) override;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -89,7 +89,7 @@ void Config::setupUserConfig() {
     QString localEtcPath = QString(PREFIX "/etc/skyscraper/");
 
     if (!QFileInfo::exists(localEtcPath)) {
-        // RetroPie installation type
+        // Non-Windows installation type
         return;
     }
 

--- a/src/esgamelist.cpp
+++ b/src/esgamelist.cpp
@@ -132,8 +132,10 @@ QString ESGameList::getAbsoluteFileName(QString fileName) {
     return "";
 }
 
-QList<QString> ESGameList::getSearchNames(const QFileInfo &info) {
+QList<QString> ESGameList::getSearchNames(const QFileInfo &info, QString &debug) {
     QList<QString> searchNames;
-    searchNames.append(info.fileName());
+    QString fileName = info.fileName();
+    debug.append("Filename: '" + fileName + "'\n");
+    searchNames.append(fileName);
     return searchNames;
 }

--- a/src/esgamelist.h
+++ b/src/esgamelist.h
@@ -37,7 +37,7 @@ public:
     ESGameList(Settings *config, QSharedPointer<NetManager> manager);
 
 private:
-    QList<QString> getSearchNames(const QFileInfo &info) override;
+    QList<QString> getSearchNames(const QFileInfo &info, QString &debug) override;
     void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
                           QString platform) override;
     void getGameData(GameEntry &game) override;

--- a/src/igdb.cpp
+++ b/src/igdb.cpp
@@ -271,30 +271,43 @@ void Igdb::getRating(GameEntry &game) {
     }
 }
 
-QList<QString> Igdb::getSearchNames(const QFileInfo &info) {
-    QString baseName = info.completeBaseName();
+QList<QString> Igdb::getSearchNames(const QFileInfo &info, QString &debug) {
+    QString baseName = info.baseName();
+    QString searchName = baseName;
+
+    debug.append("Base name: '" + baseName + "'\n");
 
     if (!config->aliasMap[baseName].isEmpty()) {
-        baseName = config->aliasMap[baseName];
+        debug.append("'aliasMap.csv' entry found\n");
+        QString aliasName = config->aliasMap[baseName];
+        debug.append("Alias name: '" + aliasName + "'\n");
+        searchName = aliasName;
     } else if (info.suffix() == "lha") {
         QString nameWithSpaces = config->whdLoadMap[baseName].first;
         if (nameWithSpaces.isEmpty()) {
-            baseName = NameTools::getNameWithSpaces(baseName);
+            searchName = NameTools::getNameWithSpaces(baseName);
         } else {
-            baseName = nameWithSpaces;
+            debug.append("'whdload_db.xml' entry found\n");
+            searchName = nameWithSpaces;
+            debug.append("Entry name: '" + searchName + "'\n");
         }
     } else if (config->platform == "scummvm") {
-        baseName = NameTools::getScummName(baseName, config->scummIni);
-    } else if ((config->platform == "neogeo" || config->platform == "arcade" ||
+        searchName = NameTools::getScummName(baseName, config->scummIni);
+    } else if ((config->platform == "neogeo" ||
+                config->platform == "arcade" ||
                 config->platform == "mame-advmame" ||
                 config->platform == "mame-libretro" ||
                 config->platform == "mame-mame4all" ||
                 config->platform == "fba") &&
-               !config->mameMap[baseName].isEmpty()) {
-        baseName = config->mameMap[baseName];
+                !config->mameMap[baseName].isEmpty()) {
+        debug.append("'mameMap.csv' entry found\n");
+        searchName = config->mameMap[baseName];
+        debug.append("Entry name: '" + searchName + "'\n");
     }
-    baseName = StrTools::stripBrackets(baseName);
+
     QList<QString> searchNames;
-    searchNames.append(baseName);
+
+    searchName = StrTools::stripBrackets(baseName);
+    searchNames.append(searchName);
     return searchNames;
 }

--- a/src/igdb.h
+++ b/src/igdb.h
@@ -55,7 +55,7 @@ private:
     void getDescription(GameEntry &game) override;
     void getRating(GameEntry &game) override;
 
-    QList<QString> getSearchNames(const QFileInfo &info) override;
+    QList<QString> getSearchNames(const QFileInfo &info, QString &debug) override;
 
     QJsonDocument jsonDoc;
     QJsonObject jsonObj;

--- a/src/openretro.cpp
+++ b/src/openretro.cpp
@@ -340,9 +340,13 @@ void OpenRetro::getMarquee(GameEntry &game) {
     }
 }
 
-QList<QString> OpenRetro::getSearchNames(const QFileInfo &info) {
-    QString baseName = info.completeBaseName();
+QList<QString> OpenRetro::getSearchNames(const QFileInfo &info, QString &debug) {
+    QString baseName = info.baseName();
     QList<QString> searchNames;
+    QString searchName = baseName;
+
+    debug.append("Base name: '" + baseName + "'\n");
+
     bool isAga = false;
     // Look for '_aga_' or '[aga]' with the last char optional
     if (QRegularExpression("[_[]{1}(Aga|AGA)[_\\]]{0,1}")
@@ -351,49 +355,55 @@ QList<QString> OpenRetro::getSearchNames(const QFileInfo &info) {
         isAga = true;
     }
 
-    if (config->scraper != "import") {
-        if (!config->aliasMap[baseName].isEmpty()) {
-            baseName = config->aliasMap[baseName];
-        } else if (info.suffix() == "lha") {
-            // Pass 1 is uuid from whdload_db.xml
-            if (!config->whdLoadMap[baseName].second.isEmpty()) {
-                searchNames.append("/game/" +
-                                   config->whdLoadMap[baseName].second);
-            }
-            // Pass 2 is either from <name> tag in whdload_db.xml or by adding
-            // spaces
-            QString nameWithSpaces = config->whdLoadMap[baseName].first;
-            if (nameWithSpaces.isEmpty()) {
-                baseName = NameTools::getNameWithSpaces(baseName);
-            } else {
-                baseName = nameWithSpaces;
-            }
-        } else if (config->platform == "scummvm") {
-            baseName = NameTools::getScummName(baseName, config->scummIni);
-        } else if ((config->platform == "neogeo" ||
-                    config->platform == "arcade" ||
-                    config->platform == "mame-advmame" ||
-                    config->platform == "mame-libretro" ||
-                    config->platform == "mame-mame4all" ||
-                    config->platform == "fba") &&
-                   !config->mameMap[baseName].isEmpty()) {
-            baseName = config->mameMap[baseName];
+    if (!config->aliasMap[baseName].isEmpty()) {
+        debug.append("'aliasMap.csv' entry found\n");
+        QString aliasName = config->aliasMap[baseName];
+        debug.append("Alias name: '" + aliasName + "'\n");
+        searchName = aliasName;
+    } else if (info.suffix() == "lha") {
+        // Pass 1 is uuid from whdload_db.xml
+        if (!config->whdLoadMap[baseName].second.isEmpty()) {
+            searchName = "/game/" + config->whdLoadMap[baseName].second;
+            searchNames.append(searchName);
         }
+        // Pass 2 is either from <name> tag in whdload_db.xml or by adding
+        // spaces
+        QString nameWithSpaces = config->whdLoadMap[baseName].first;
+        if (nameWithSpaces.isEmpty()) {
+            searchName = NameTools::getNameWithSpaces(baseName);
+        } else {
+            debug.append("'whdload_db.xml' entry found\n");
+            searchName = nameWithSpaces;
+            debug.append("Entry name: '" + searchName + "'\n");
+        }
+    } else if (config->platform == "scummvm") {
+        searchName = NameTools::getScummName(baseName, config->scummIni);
+    } else if ((config->platform == "neogeo" ||
+                config->platform == "arcade" ||
+                config->platform == "mame-advmame" ||
+                config->platform == "mame-libretro" ||
+                config->platform == "mame-mame4all" ||
+                config->platform == "fba") &&
+                !config->mameMap[baseName].isEmpty()) {
+        debug.append("'mameMap.csv' entry found\n");
+        searchName = config->mameMap[baseName];
+        debug.append("Entry name: '" + searchName + "'\n");
     }
 
-    baseName = NameTools::getUrlQueryName(baseName, 2);
+    searchName = NameTools::getUrlQueryName(searchName, 2);
 
-    if (!baseName.isEmpty()) {
+    if (!searchName.isEmpty()) {
         if (isAga) {
-            searchNames.append("/browse?q=" + baseName + "+aga");
+            searchName = "/browse?q=" + searchName + "+aga";
+            searchNames.append(searchName);
         }
-        searchNames.append("/browse?q=" + baseName);
+        searchNames.append("/browse?q=" + searchName);
     }
 
-    if (baseName.indexOf(":") != -1 || baseName.indexOf("-") != -1) {
-        baseName = baseName.left(baseName.indexOf(":")).simplified();
-        baseName = baseName.left(baseName.indexOf("-")).simplified();
-        searchNames.append("/browse?q=" + baseName);
+    if (searchName.indexOf(":") != -1 || searchName.indexOf("-") != -1) {
+        searchName = searchName.left(searchName.indexOf(":")).simplified();
+        searchName = searchName.left(searchName.indexOf("-")).simplified();
+        searchNames.append("/browse?q=" + searchName);
     }
 
     return searchNames;

--- a/src/openretro.h
+++ b/src/openretro.h
@@ -35,7 +35,7 @@ public:
     OpenRetro(Settings *config, QSharedPointer<NetManager> manager);
 
 private:
-    QList<QString> getSearchNames(const QFileInfo &info) override;
+    QList<QString> getSearchNames(const QFileInfo &info, QString &debug) override;
     void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
                           QString platform) override;
     void getGameData(GameEntry &game) override;

--- a/src/scraperworker.cpp
+++ b/src/scraperworker.cpp
@@ -104,7 +104,10 @@ void ScraperWorker::run() {
             cacheId = NameTools::getCacheId(info);
             cache->addQuickId(info, cacheId);
         }
+
+        // compareTitle is what SkyScraper uses as the title internally and with cache, distinctly separate from search query and/or result from a scraping module
         QString compareTitle = scraper->getCompareTitle(info);
+        debug.append("Compare title: '" + compareTitle + "'\n");
 
         // For Amiga platform, change to subplatforms if detected as such
         if (config.platform == "amiga") {
@@ -529,9 +532,7 @@ GameEntry ScraperWorker::getBestEntry(const QList<GameEntry> &gameEntries,
                                       int &lowestDistance) {
     GameEntry game;
 
-    // If scraper isn't filename search based, always return first entry
-    QStringList const directMatchScrapers = {"cache", "import", "arcadedb",
-                                             "screenscraper", "esgamelist"};
+    // If scraper isn't filename/hash search based, always return first entry
     if (directMatchScrapers.contains(config.scraper) ||
         (config.scraper == "openretro" && gameEntries.first().url.isEmpty())) {
         lowestDistance = 0;

--- a/src/scraperworker.h
+++ b/src/scraperworker.h
@@ -76,6 +76,12 @@ private:
                        const int &lowestDistance);
 
     bool limitReached(QString &output);
+
+    QStringList const directMatchScrapers = {"cache", "import", "arcadedb",
+                                            "screenscraper", "esgamelist"};
+    QStringList const searchBasedScrapers = {"thegamesdb", "mobygames",
+                                            "igdb", "worldofspectrum"};
+    QStringList const variableScrapers = {"openretro"};
 };
 
 #endif // SCRAPERWORKER_H

--- a/src/screenscraper.cpp
+++ b/src/screenscraper.cpp
@@ -494,7 +494,22 @@ void ScreenScraper::getVideo(GameEntry &game) {
     }
 }
 
-QList<QString> ScreenScraper::getSearchNames(const QFileInfo &info) {
+QList<QString> ScreenScraper::getSearchNames(const QFileInfo &info, QString &debug) {
+    QString baseName = info.baseName();
+    QList<QString> searchNames;
+    QString searchName = baseName;
+
+    debug.append("Base name: '" + baseName + "'\n");
+
+    if (!config->aliasMap[baseName].isEmpty()) {
+        debug.append("'aliasMap.csv' entry found\n");
+        QString aliasName = config->aliasMap[baseName];
+        debug.append("Alias name: '" + aliasName + "'\n");
+        searchName = "romnom=" + QUrl::toPercentEncoding(aliasName, "()");
+        searchNames.append(searchName);
+        return searchNames;
+    }
+
     QList<QString> hashList;
     QCryptographicHash md5(QCryptographicHash::Md5);
     QCryptographicHash sha1(QCryptographicHash::Sha1);
@@ -596,7 +611,7 @@ QList<QString> ScreenScraper::getSearchNames(const QFileInfo &info) {
     hashList.append(md5Result.toUpper());
     hashList.append(sha1Result.toUpper());
 
-    QList<QString> searchNames;
+    // Only one searchName, but direct match query
     if (info.size() != 0) {
         searchNames.append("crc=" + hashList.at(1) + "&md5=" + hashList.at(2) +
                            "&sha1=" + hashList.at(3) +

--- a/src/screenscraper.h
+++ b/src/screenscraper.h
@@ -45,7 +45,7 @@ public:
 private:
     QTimer limitTimer;
     QEventLoop limiter;
-    QList<QString> getSearchNames(const QFileInfo &info) override;
+    QList<QString> getSearchNames(const QFileInfo &info, QString &debug) override;
     void getSearchResults(QList<GameEntry> &gameEntries, QString searchName,
                           QString) override;
     void getGameData(GameEntry &game) override;

--- a/src/skyscraper.cpp
+++ b/src/skyscraper.cpp
@@ -1312,10 +1312,8 @@ void Skyscraper::loadWhdLoadMap() {
                     QDomNode gameNode = gameNodes.at(a);
                     QPair<QString, QString> gamePair;
                     gamePair.first = gameNode.firstChildElement("name").text();
-                    gamePair.second =
-                        gameNode.firstChildElement("variant_uuid").text();
-                    config.whdLoadMap[gameNode.toElement().attribute(
-                        "filename")] = gamePair;
+                    gamePair.second = gameNode.firstChildElement("variant_uuid").text();
+                    config.whdLoadMap[gameNode.toElement().attribute("filename")] = gamePair;
                 }
             }
         }

--- a/src/thegamesdb.cpp
+++ b/src/thegamesdb.cpp
@@ -111,8 +111,7 @@ void TheGamesDb::getSearchResults(QList<GameEntry> &gameEntries,
         bool matchPlafId = gamePlafId == platformId;
         if (platformMatch(game.platform, platform) || matchPlafId) {
             if (matchPlafId) {
-                qDebug() << "platforms_id match " << QString::number(gamePlafId)
-                         << "\n";
+                qDebug() << "platforms_id match " << QString::number(gamePlafId) << "\n";
             }
             gameEntries.append(game);
         }


### PR DESCRIPTION
PR came from this issue: https://github.com/Gemba/skyscraper/issues/10

Tested and successfully working with Screenscraper; tested and not breaking all other scrapers. Additional testing support would be helpful, since I'm not familiar with these DBs.

## Core Feature
- Added support for `aliasMap.csv` to Screenscraper, ArcadeDB ("direct match", e.g. filename/hash) scraping modules, except for "local/utility" scrapers, like import or EmulationStation Game List scrapers
    - When a matching entry exists, will search instead by name defined as alias
- Extracted constant lists of `directMatchScrapers`, `searchMatchScrapers`, and `variableScrapers` to `scraperworker.h`, representing all supported scraper modules
- Updated `aliasMap.csv` comments to be more clear and follow new behavior
- Added multiple debugging statements
- Created new variables in addition to `baseName` to accurately represent strings they represent, for clarity, instead of recycling the same name
- Some scrapers were using `QFileInfo.completeBaseName()` and `QFileInfo.baseName()` ambiguously. I checked DB APIs behavior/expectations here and made sure to correct/make these consistent with what's expected

## Dev Container-Related
- Added `postCreateCommand.sh` for additional flexibility, including automated setup for `git`
- Updated `devcontainer.json`
    - Extracted `postCreateCommand` of `devcontainer.json` to `postCreateCommand.sh`
    - Added basic VSCode extensions
- Updated `Dockerfile`
    - Added some core development applications
    - Automated `apt upgrade`
    - Improved comments

## Developer Experience
- Created `build.sh` - Bash script to automate full clean build of Skyscraper

## General/Clerical
- Improved comments
- Minor whitespace, grammar, readability, etc. changes
- Removed redundant newline addition to `qDebug()` - `qDebug()`  deconstructor already adds newline,creating lots of blank lines in debug output