### PR TITLE
Symlink rom fix

### DIFF
--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -188,23 +188,23 @@ void EmulationStation::assembleList(QString &finalOutput,
         }
         QFileInfo entryInfo(entry.path);
         // always use canonical file path to ROM
-        entry.path = entryInfo.canonicalFilePath();
+        entry.path = entryInfo.absoluteFilePath();
 
         // Check if path is exactly one subfolder beneath root platform
         // folder (has one more '/') and uses *.cue suffix
-        QString entryCanonicalDir = entryInfo.canonicalPath();
-        if (cueSuffix && entryCanonicalDir.count("/") ==
+        QString entryAbsoluteDir = entryInfo.absolutePath();
+        if (cueSuffix && entryAbsoluteDir.count("/") ==
                              config->inputFolder.count("/") + 1) {
             // Check if subfolder has exactly one ROM, in which case we
             // use <folder>
-            if (QDir(entryCanonicalDir, extensions).count() == 1) {
+            if (QDir(entryAbsoluteDir, extensions).count() == 1) {
                 entry.isFolder = true;
-                entry.path = entryCanonicalDir;
+                entry.path = entryAbsoluteDir;
             }
         }
 
         // inputDir is canonical
-        QString subPath = inputDir.relativeFilePath(entryCanonicalDir);
+        QString subPath = inputDir.relativeFilePath(entryAbsoluteDir);
         if (subPath != ".") {
             // <folder> element(s) are needed
             addFolder(config->inputFolder, subPath, gameEntries, added);

--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -187,7 +187,7 @@ void EmulationStation::assembleList(QString &finalOutput,
             }
         }
         QFileInfo entryInfo(entry.path);
-        // always use canonical file path to ROM
+        // always use absolute file path to ROM
         entry.path = entryInfo.absoluteFilePath();
 
         // Check if path is exactly one subfolder beneath root platform


### PR DESCRIPTION
This seems to fix #38 (at least for my use case). You will definitely want to take a hard look at whether I've broken what you were trying to accomplish with https://github.com/Gemba/skyscraper/commit/4aff22586d848f9974d2464d5372b8986a0e64c0 though, as I'm not clear on whether there was a reason for the switch from absolute to canonical there.

Thanks!