### PR TITLE
Fix #38

### DIFF
--- a/src/skyscraper.h
+++ b/src/skyscraper.h
@@ -77,6 +77,7 @@ private:
     void loadWhdLoadMap();
     void setRegionPrios();
     void setLangPrios();
+    QString normalizePath(QFileInfo fileInfo);
     // void migrate(QString filename);
 
     AbstractFrontend *frontend;


### PR DESCRIPTION
Plus cornercase solved: When default ES inputFolder is symlinked from /home/pi/RetroPie/roms to /home/pi/roms f.i. and user provides from that symlink downwards rom files on CLI.