### PR TITLE
Dev container improvement and build automation script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,17 @@
 # syntax=docker/dockerfile:1
 
-# Dev Container Template (https://containers.dev/templates) based on latest Debian "bookworm" release or use vanilla Debian from Docker Hub instead
+# Dev Container Template (https://containers.dev/templates) based on latest Debian "bookworm" release or use vanilla Debian image from Docker Hub instead
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 # FROM debian:bookworm
 
 # Update, upgrade, and install necessary packages
-RUN sudo apt update && sudo apt upgrade && sudo apt install -y qtbase5-dev
+RUN sudo apt update && sudo apt upgrade -y && sudo apt install -y qtbase5-dev
 
-# Make (compile) and install Skyscraper
+# Set QT version for qmake/make (compilation and installation) of Skyscraper
 RUN QT_SELECT=5
-# These can not be done in a Dev Container, as workspace doesn't exist until after Docker container is created from image, so commands are unaware of source files. Instead, do in `postCreateCommand` of `devcontainer.json`.
-# RUN qmake && make -j$(nproc) && sudo make install 
+
+# Install apps
+# `neovim` for editing
+# `gdb` for debugging
+# `file` for checking that `Skyscraper` binary has debugging info
+RUN sudo apt install neovim gdb file -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,10 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-azuretools.vscode-docker"
+				"ms-azuretools.vscode-docker",
+				"ms-vscode.cpptools-extension-pack",
+				"mechatroner.rainbow-csv",
+				"ryu1kn.partial-diff"
 			]
 		}
 	},
@@ -28,5 +31,5 @@
 	// "remoteUser": "root"
 
 	// Actions that are run after the container is created
-	"postCreateCommand": "qmake && make -j$(nproc) && sudo make install"
+	"postCreateCommand": "./.devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Running $0 script as a part of the 'postCreateCommand' in 'devcontainer.json'"
+
+# Configure git
+echo "Configuring git"
+git config --global --add safe.directory /workspaces/skyscraper
+# git config --global user.email "<ADD_USER_EMAIL_HERE>"
+# git config --global user.name "<ADD_USER_NAME_HERE>"
+
+# Set aliases
+echo "Setting aliases (in ~/.bash_aliases)"
+echo 'alias ll="ls -lah"' >> ~/.bash_aliases
+
+# Create ROMs directory
+mkdir -p ~/RetroPie/roms/nes

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+### Bash script to automate full clean build of Skyscraper 
+
+# Cleanup
+rm .qmake.stash
+make clean
+
+# Make/build and install
+qmake
+make -j$(nproc)
+sudo make install
+


### PR DESCRIPTION
- Fix Dockerfile `apt upgrade` automation
- Don't build/install Skyscraper after dev container build
- Configure git for dev container
- Add core development applications to dev container
- Add sane default VS Code extensions to dev container
- Extract `postCreateCommand.sh` for additional Dev Container configuration
- Add `build.sh` for easy building