### PR TITLE
Populate release date in search results; if game title contains year (YYYY) use that to work out "Skyscraper's choice" based on release date.

### DIFF
--- a/src/arcadedb.cpp
+++ b/src/arcadedb.cpp
@@ -72,6 +72,7 @@ void ArcadeDB::getSearchResults(QList<GameEntry> &gameEntries,
 
     game.title = jsonObj.value("title").toString();
     game.platform = platform;
+    game.releaseDate = jsonObj.value("year").toString();
     gameEntries.append(game);
 }
 

--- a/src/mobygames.cpp
+++ b/src/mobygames.cpp
@@ -121,6 +121,7 @@ void MobyGames::getSearchResults(QList<GameEntry> &gameEntries,
                        StrTools::unMagic(
                            "175;229;170;189;188;202;211;117;164;165;185;209;"
                            "164;234;180;155;199;209;224;231;193;190;173;175");
+            game.releaseDate = jsonPlatform["first_release_date"].toString();
             game.platform = jsonPlatform["platform_name"].toString();
             bool matchPlafId = gamePlafId == platformId;
             if (platformMatch(game.platform, platform) || matchPlafId) {

--- a/src/scraperworker.h
+++ b/src/scraperworker.h
@@ -67,20 +67,22 @@ private:
     unsigned int editDistance(const std::string &s1, const std::string &s2);
 
     GameEntry getBestEntry(const QList<GameEntry> &gameEntries,
-                           QString compareTitle, int &lowestDistance);
+                           QString compareTitle, int compareYear,
+                           int &lowestDistance);
     GameEntry getEntryFromUser(const QList<GameEntry> &gameEntries,
                                const GameEntry &suggestedGame,
                                const QString &compareTitle,
                                int &lowestDistance);
     int getSearchMatch(const QString &title, const QString &compareTitle,
                        const int &lowestDistance);
+    int getReleaseYear(const QString releaseDateString);
 
     bool limitReached(QString &output);
 
     QStringList const directMatchScrapers = {"cache", "import", "arcadedb",
-                                            "screenscraper", "esgamelist"};
-    QStringList const searchBasedScrapers = {"thegamesdb", "mobygames",
-                                            "igdb", "worldofspectrum"};
+                                             "screenscraper", "esgamelist"};
+    QStringList const searchBasedScrapers = {"thegamesdb", "mobygames", "igdb",
+                                             "worldofspectrum"};
     QStringList const variableScrapers = {"openretro"};
 };
 

--- a/src/screenscraper.cpp
+++ b/src/screenscraper.cpp
@@ -253,6 +253,7 @@ void ScreenScraper::getSearchResults(QList<GameEntry> &gameEntries,
 
     game.url = gameUrl;
     game.platform = jsonObj["systeme"].toObject()["text"].toString();
+    game.releaseDate = getJsonText(jsonObj["dates"].toArray(), REGION);
 
     // Only check if platform is empty, it's always correct when using
     // ScreenScraper

--- a/src/thegamesdb.cpp
+++ b/src/thegamesdb.cpp
@@ -106,6 +106,8 @@ void TheGamesDb::getSearchResults(QList<GameEntry> &gameEntries,
         // Remove anything at the end with a parentheses. 'thegamesdb' has a
         // habit of adding for instance '(1993)' to the name.
         game.title = game.title.left(game.title.indexOf("(")).simplified();
+        if (jsonGame["release_date"] != QJsonValue::Undefined)
+            game.releaseDate = jsonGame["release_date"].toString();
         int gamePlafId = jsonGame["platform"].toInt();
         game.platform = platformMap[QString::number(gamePlafId)].toString();
         bool matchPlafId = gamePlafId == platformId;


### PR DESCRIPTION
This is especially relevant for PC games. If a game has had a remake on the same platform, scraping media for that game often involves guesswork. In interactive mode, the scraper (e.g. mobygames or thegamesdb) may show a list that includes your search title multiple times. Only one instance is the one you want, but there's nothing to indicate which is right.

An example is the Resident Evil 4 remake with a search title of "Resident Evil 4" and platform of "pc" (or "ags"). Though not a remake, another example is "Stray" which, in interactive mode, displays multiple games with the same title, but doesn't give enough information to choose correctly.

This PR does a few things:

- it populates releaseDate for arcadedb (year only), igdb, mobygames, and thegamesdb
- it displays the release date in interactive mode to aid in making the correct selection
- if the search title includes a year, "(YYYY)", then "Skyscraper's choice" in interactive mode will be a game released that year

The way to trigger the year-matching feature in interactive mode is to name your game file appropriately - "Resident Evil 4 (2023)", "Stray (2022)", etc. If the year is not included in the file name, Skyscraper behaves the same as it did before this PR.

The year-matching from the search title aligns with scraping media for films and TV shows.