### PR TITLE
Avoid copying a QFile in Nametools (fixes #64)

### DIFF
--- a/src/nametools.cpp
+++ b/src/nametools.cpp
@@ -56,7 +56,7 @@ QString NameTools::getScummName(const QFileInfo &info, const QString baseName,
         // test the other way around: ROM name is custom but may contain
         // game id
         if (info.isFile()) {
-            QFile romFile = QFile(info.absoluteFilePath());
+            QFile romFile(info.absoluteFilePath());
             if (romFile.open(QIODevice::ReadOnly) && !romFile.atEnd()) {
                 QString gameId = romFile.readLine();
                 settings->beginGroup(gameId.trimmed());


### PR DESCRIPTION
To quote myself on issue #64:

> Hi! I ran into exactly the same issue, and I believe it's because that line of code in Skyscraper is technically incorrect. See, this C++ syntax:
> 
> ```c++
> QFile romFile = QFile(info.absoluteFilePath());
> ```
> 
> means to create a temporary `QFile` object from the given absolute file path, and then _copy_ from that object to a separate `QFile` object referenced by the name `romFile`. This is incorrect because all Qt `QObject` types, including `QFile`, are deliberately made non-copyable.
> 
> I suspect the reason the incorrect code is working anyway for Linux users is that C++ has _incredibly_ complicated optimisation rules, one of which allows it to potentially skip the copying step if the compiler can figure out that it's not necessary. These rules aren't consistently applied across all compilers and all platforms, so the mistake may not have been caught as an error for GCC users on Linux in the same way it's being caught for Clang users on MacOS. [In fact this exact situation is mentioned as a potential issue in Qt's documentation!](https://doc.qt.io/qt-6/qtclasshelpermacros-qtcore-proxy.html#Q_DISABLE_COPY)
> 
> The correct syntax would directly create a single `QFile` object using the given path, with no temporary object or potential copying, and looks like this:
> 
> ```c++
> QFile romFile(info.absoluteFilePath());
> ```

This change fixes Skyscraper compiling on MacOS, and since it's the intended way to construct a QFile from a file path it will work fine on Linux as well. There's actually a number of other places in the codebase that use the `QFile name(path);` construction syntax already.