### PR TITLE
fix: alias for nproc on osx update_skyscraper.sh

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/skyscraper.pro
+++ b/skyscraper.pro
@@ -3,6 +3,7 @@ TARGET = Skyscraper
 DEPENDPATH += .
 INCLUDEPATH += .
 CONFIG += release
+CONFIG += c++1z
 QT += core network xml
 QMAKE_CXXFLAGS += -std=c++17
 

--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -52,7 +52,7 @@
 		echo "--- Cleaning out old build if one exists ---"
 		make --ignore-errors clean
 		rm -f .qmake.stash
-		qmake || handle_error "clean old"
+		QT_SELECT=5 qmake || handle_error "clean old"
 
 		if [[ "$OSTYPE" == "darwin"* ]]; then
 			echo

--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -60,6 +60,8 @@
 			mv VERSION VERSION.txt
 			sed -i '' "s|CC *= .*|CC             = /usr/bin/gcc|" Makefile
 			sed -i '' "s|CXX *= .*|CXX           = /usr/bin/g++|" Makefile
+
+      			nproc="sysctl -n hw.physicalcpu"
 		fi
 
 		echo


### PR DESCRIPTION
nproc isn't a command on OSX and the result is the make process is slower than it needs to be. This adds a alias for nproc which returns the number of logical cores:

https://github.com/memkind/memkind/issues/33#issuecomment-540614162