### PR TITLE
fix: alias for nproc on osx update_skyscraper.sh

### DIFF
--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -60,6 +60,7 @@
 			mv VERSION VERSION.txt
 			sed -i '' "s|CC *= .*|CC             = /usr/bin/gcc|" Makefile
 			sed -i '' "s|CXX *= .*|CXX           = /usr/bin/g++|" Makefile
+   			nproc="sysctl -n hw.physicalcpu"
 		fi
 
 		echo


### PR DESCRIPTION
nproc isn't a command on OSX and the result is the make process is slower than it needs to be. This adds a alias for nproc which returns the number of logical cores:

https://github.com/memkind/memkind/issues/33#issuecomment-540614162