### PR TITLE
fix: amend sed when wget response for version is on single line

### DIFF
--- a/update_skyscraper.sh
+++ b/update_skyscraper.sh
@@ -18,7 +18,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
 {
-    LATEST=$(wget -q -O - "https://api.github.com/repos/Gemba/skyscraper/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    LATEST=$(wget -q -O - "https://api.github.com/repos/Gemba/skyscraper/releases/latest" | grep '"tag_name":' | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p')
     [[ -z "$LATEST" ]] && printf '%s\n' "--- Remote server unreachable. Check internet connectivity. Exiting. ---" && exit 1
 
     handle_error() {


### PR DESCRIPTION
Bit of a weird one here but will try to explain.

I had a report from a user on Fedora 40 who was trying to install Skyscraper and was running into an issue:

Trying to install Skyscraper using the instructions provided they have the following output:

```
--- Fetching Skyscraper v* Various community suggestions implemented\r\n* All details [here](https://gemba.github.io/skyscraper/CHANGELOG/#version-3120-2024-07-01) ---
0 files              100% [=================================================================>]  118.61K    --.-KB/s
                          [Files: 0  Bytes: 118.61K [344.81KB/s] Redirects: 0  Todo: 0  Error]
--- Failed to fetch Skyscraper v* Various community suggestions implemented\r\n* All details [here](https://gemba.github.io/skyscraper/CHANGELOG/#version-3120-2024-07-01), exiting with code 8 ---
```

I downloaded a Fedora40 Image and was able to reproduce the issue. 

What's happening is that the line which is fetching the current version from the github release API isn't working as expected.
The root cause is that the 'wget' command here, instead of returning the json response 'pretty printed' with line breaks is instead returning the response on a single line. Consequentially the piped grep and sed commands are extracting the 'tag_name' incorrectly, which causes the subsequent download command to fail. 

There are two possible reasons as far as I can work out:

1) wget on this system isn't parsing the 'pretty printed' response as expected and is compressing it onto a single line 
2) wget is forming the request in such a way that the github API isn't responding with a pretty printed response

I've tested the Skyscraper install script on multiple Linux distros recently including Fedora28, Debian 12, Ubuntu 22 and macOS 14.5 and none of them have this behaviour, but it remains a fact that it seems to be happening with Fedora40 for whatever reason.

I spent a bit of time trying to work out why this was happening without making much progress before deciding that just changing the sed command to handle both types of response was less hassle.

As such the PR submitted will extract the version correctly from both 'pretty printed' json responses and also 'single line' json responses.