### PR TITLE
Restructure skipExisting checks to reuse previous values

### DIFF
--- a/src/attractmode.cpp
+++ b/src/attractmode.cpp
@@ -81,6 +81,7 @@ bool AttractMode::skipExisting(QList<GameEntry> &gameEntries,
     gameEntries = oldEntries;
 
     printf("Resolving missing entries...");
+    fflush(stdout);
     int dots = 0;
     for (int a = 0; a < gameEntries.length(); ++a) {
         dots++;
@@ -88,8 +89,9 @@ bool AttractMode::skipExisting(QList<GameEntry> &gameEntries,
             printf(".");
             fflush(stdout);
         }
+        QString baseName = gameEntries.at(a).baseName;
         for (int b = 0; b < queue->length(); ++b) {
-            if (gameEntries.at(a).baseName == queue->at(b).completeBaseName()) {
+            if (baseName == queue->at(b).completeBaseName()) {
                 queue->removeAt(b);
                 // We assume baseName is unique, so break after getting first
                 // hit

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1260,6 +1260,7 @@ void Cache::readPriorities() {
     QFile prioFile(cacheDir.absolutePath() + "/priorities.xml");
     printf("Looking for optional '\033[1;33mpriorities.xml\033[0m' file in "
            "cache folder... ");
+    fflush(stdout);
     if (prioFile.open(QIODevice::ReadOnly)) {
         printf("\033[1;32mFound!\033[0m\n");
         if (!prioDoc.setContent(prioFile.readAll())) {

--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -59,6 +59,7 @@ bool EmulationStation::skipExisting(QList<GameEntry> &gameEntries,
     gameEntries = oldEntries;
 
     printf("Resolving missing entries...");
+    fflush(stdout);
     int dots = 0;
     for (int a = 0; a < gameEntries.length(); ++a) {
         dots++;
@@ -66,20 +67,24 @@ bool EmulationStation::skipExisting(QList<GameEntry> &gameEntries,
             printf(".");
             fflush(stdout);
         }
+
         QFileInfo current(gameEntries.at(a).path);
-        for (int b = 0; b < queue->length(); ++b) {
-            if (current.isFile()) {
-                if (current.fileName() == queue->at(b).fileName()) {
+        if (current.isFile()) {
+            QString fileName = current.fileName();
+            for (int b = 0; b < queue->length(); ++b) {
+                if (fileName == queue->at(b).fileName()) {
                     queue->removeAt(b);
                     // We assume filename is unique, so break after getting
                     // first hit
                     break;
                 }
-            } else if (current.isDir()) {
-                // Use current.canonicalFilePath here since it is already a
-                // path. Otherwise it will use the parent folder
-                if (current.canonicalFilePath() ==
-                    queue->at(b).canonicalPath()) {
+            }
+        } else if (current.isDir()) {
+            // Use current.canonicalFilePath here since it is already a
+            // path. Otherwise it will use the parent folder
+            QString filePath = current.canonicalFilePath();
+            for (int b = 0; b < queue->length(); ++b) {
+                if (filePath == queue->at(b).canonicalPath()) {
                     queue->removeAt(b);
                     // We assume filename is unique, so break after getting
                     // first hit
@@ -88,6 +93,7 @@ bool EmulationStation::skipExisting(QList<GameEntry> &gameEntries,
             }
         }
     }
+
     return true;
 }
 

--- a/src/pegasus.cpp
+++ b/src/pegasus.cpp
@@ -215,6 +215,7 @@ bool Pegasus::skipExisting(QList<GameEntry> &gameEntries,
     gameEntries = oldEntries;
 
     printf("Resolving missing entries...");
+    fflush(stdout);
     int dots = 0;
     for (int a = 0; a < gameEntries.length(); ++a) {
         dots++;
@@ -222,19 +223,24 @@ bool Pegasus::skipExisting(QList<GameEntry> &gameEntries,
             printf(".");
             fflush(stdout);
         }
+
         QFileInfo current(gameEntries.at(a).path);
-        for (int b = 0; b < queue->length(); ++b) {
-            if (current.isFile()) {
-                if (current.fileName() == queue->at(b).fileName()) {
+        if (current.isFile()) {
+            QString fileName = current.fileName();
+            for (int b = 0; b < queue->length(); ++b) {
+                if (fileName == queue->at(b).fileName()) {
                     queue->removeAt(b);
                     // We assume filename is unique, so break after getting
                     // first hit
                     break;
                 }
-            } else if (current.isDir()) {
-                // Use current.absoluteFilePath here since it is already a path.
-                // Otherwise it will use the parent folder
-                if (current.absoluteFilePath() == queue->at(b).absolutePath()) {
+            }
+        } else if (current.isDir()) {
+            // Use current.absoluteFilePath here since it is already a path.
+            // Otherwise it will use the parent folder
+            QString filePath = current.absoluteFilePath();
+            for (int b = 0; b < queue->length(); ++b) {
+                if (filePath == queue->at(b).absoluteFilePath()) {
                     queue->removeAt(b);
                     // We assume filename is unique, so break after getting
                     // first hit
@@ -243,6 +249,7 @@ bool Pegasus::skipExisting(QList<GameEntry> &gameEntries,
             }
         }
     }
+
     return true;
 }
 


### PR DESCRIPTION
Another bottleneck : D

For a large db.xml + a sizeable gamelist this got really expensive to keep doing the same checks. Restructured it to save information that can be reused.

This took my local skipExisting check from ~5mins to ~5seconds