### PR TITLE
Refactor ScreenScraper::getPropertyValue() to Use Regular Expression for Type Comparison

### DIFF
--- a/src/screenscraper.cpp
+++ b/src/screenscraper.cpp
@@ -337,7 +337,7 @@ void ScreenScraper::getTags(GameEntry &game) {
         QString tag =
             getJsonText(jsonTags.at(a).toObject()["noms"].toArray(), LANGUE);
         if (!tag.isEmpty()) {
-            game.tags.append(tag + ", ");
+            game.tags.append(tag % ", ");
         }
     }
 
@@ -612,14 +612,13 @@ QString ScreenScraper::getUrlOrTextPropertyValue(const QJsonObject &jsonObj,
 QString ScreenScraper::getPropertyValue(const QJsonArray &jsonArr,
                                         const QList<QString> &locPrios,
                                         const QString &locationKey,
-                                        QString type) {
+                                        const QString &type) {
     for (const auto &location : locPrios) {
         for (const auto &jsonVal : jsonArr) {
             QJsonObject jsonObj = jsonVal.toObject();
-            if (type.isEmpty() ||
-                QRegularExpression(type.prepend('^').append('$'))
-                    .match(jsonObj["type"].toString())
-                    .hasMatch()) {
+            if (type.isEmpty() || QRegularExpression("^" % type % "$")
+                                      .match(jsonObj["type"].toString())
+                                      .hasMatch()) {
                 if (QString ret = getUrlOrTextPropertyValue(
                         jsonObj, locationKey, location);
                     !ret.isEmpty()) {
@@ -638,7 +637,7 @@ QString ScreenScraper::getLocalizedValue(const QJsonArray &jsonArr,
     qDebug() << "Types:" << types;
     QString ret;
     if (types.isEmpty()) {
-        ret = getPropertyValue(jsonArr, locPrios, locationKey);
+        ret = getPropertyValue(jsonArr, locPrios, locationKey, QString());
     } else {
         for (const auto &type : types) {
             ret = getPropertyValue(jsonArr, locPrios, locationKey, type);

--- a/src/screenscraper.h
+++ b/src/screenscraper.h
@@ -81,7 +81,7 @@ private:
     QString getPropertyValue(const QJsonArray &jsonArr,
                              const QList<QString> &locPrios,
                              const QString &locationKey,
-                             const QString &type = "");
+                             QString type = QString());
     int getPlatformId(const QString platform) override;
 
     QString region;

--- a/src/screenscraper.h
+++ b/src/screenscraper.h
@@ -42,6 +42,7 @@ class ScreenScraper : public AbstractScraper {
 public:
     ScreenScraper(Settings *config, QSharedPointer<NetManager> manager);
 
+
 private:
     QTimer limitTimer;
     QEventLoop limiter;
@@ -80,8 +81,7 @@ private:
                               const QList<QString> &types);
     QString getPropertyValue(const QJsonArray &jsonArr,
                              const QList<QString> &locPrios,
-                             const QString &locationKey,
-                             QString type = QString());
+                             const QString &locationKey, const QString &type);
     int getPlatformId(const QString platform) override;
 
     QString region;

--- a/src/screenscraper.h
+++ b/src/screenscraper.h
@@ -42,7 +42,6 @@ class ScreenScraper : public AbstractScraper {
 public:
     ScreenScraper(Settings *config, QSharedPointer<NetManager> manager);
 
-
 private:
     QTimer limitTimer;
     QEventLoop limiter;


### PR DESCRIPTION
### Summary
This pull request updates the type comparison logic in the `ScreenScraper::getPropertyValue()` method.

### Changes Made
- Replaced the `QString` comparison with a regular expression check.

### Impact
- This change allows for simultaneous matching of types, specifically addressing issue #101. The method can now recognize both `wheel` and `wheel-hd` in a single evaluation, improving efficiency and flexibility.

