### PR TITLE
Feature: Allow Overriding Gamelist Filename via Config.ini or CLI

### DIFF
--- a/docs/CONFIGINI.md
+++ b/docs/CONFIGINI.md
@@ -82,6 +82,7 @@ This is an alphabetical index of all configuration options including the section
 | [forceFilename](CONFIGINI.md#forcefilename)                 |    Y     |       Y        |       Y        |               |
 | [frontend](CONFIGINI.md#frontend)                           |    Y     |                |                |               |
 | [gameListBackup](CONFIGINI.md#gamelistbackup)               |    Y     |                |       Y        |               |
+| [gameListFilename](CONFIGINI.md#gamelistfilename)           |    Y     |       Y        |       Y        |               |
 | [gameListFolder](CONFIGINI.md#gamelistfolder)               |    Y     |       Y        |       Y        |               |
 | [gameListVariants](CONFIGINI.md#gamelistvariants)           |          |                |       Y        |               |
 | [hints](CONFIGINI.md#hints)                                 |    Y     |                |                |               |
@@ -153,6 +154,15 @@ Sets the game list export folder. By default Skyscraper exports the game list to
     If this is set in the `[main]` or `[<FRONTEND>]` section it will automatically add `/<PLATFORM>` to the end of the path. If you want better control consider adding it to a `[<PLATFORM>]` section instead where it will be used as is.
 
 Default value: `/home/<USER>/RetroPie/roms/<PLATFORM>`  
+Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
+
+---
+
+#### gameListFilename
+
+Sets the game list export filename. This enables you to change that to a non-default filename.
+
+Default value: depends on [frontend](FRONTENDS.md)
 Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
 
 ---

--- a/docs/CONFIGINI.md
+++ b/docs/CONFIGINI.md
@@ -82,7 +82,7 @@ This is an alphabetical index of all configuration options including the section
 | [forceFilename](CONFIGINI.md#forcefilename)                 |    Y     |       Y        |       Y        |               |
 | [frontend](CONFIGINI.md#frontend)                           |    Y     |                |                |               |
 | [gameListBackup](CONFIGINI.md#gamelistbackup)               |    Y     |                |       Y        |               |
-| [gameListFilename](CONFIGINI.md#gamelistfilename)           |    Y     |       Y        |       Y        |               |
+| [gameListFilename](CONFIGINI.md#gamelistfilename)           |          |                |       Y        |               |
 | [gameListFolder](CONFIGINI.md#gamelistfolder)               |    Y     |       Y        |       Y        |               |
 | [gameListVariants](CONFIGINI.md#gamelistvariants)           |          |                |       Y        |               |
 | [hints](CONFIGINI.md#hints)                                 |    Y     |                |                |               |
@@ -160,10 +160,10 @@ Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
 
 #### gameListFilename
 
-Sets the game list export filename. This enables you to change that to a non-default filename.
+Override the game list filename. This enables you to set a filename different from the default provided by the frontend modules.
 
-Default value: depends on [frontend](FRONTENDS.md)
-Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
+Default value: depends on [frontend](FRONTENDS.md)  
+Allowed in sections: `[<FRONTEND>]`
 
 ---
 

--- a/src/attractmode.cpp
+++ b/src/attractmode.cpp
@@ -260,7 +260,9 @@ bool AttractMode::canSkip() { return true; }
 
 QString AttractMode::getGameListFileName() {
     QFileInfo info(config->frontendExtra);
-    return QString(info.completeBaseName() % ".txt");
+    return config->gameListFilename.isEmpty()
+               ? QString(info.completeBaseName() % ".txt")
+               : config->gameListFilename;
 }
 
 QString AttractMode::getInputFolder() {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -170,6 +170,10 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
         "resource cache. It must be followed by 'COMMAND[:OPTIONS]'.\nSee "
         "'--cache help' for a full description of all functions.",
         "COMMAND[:OPTIONS]", "");
+    QCommandLineOption gamelistfilenameOption(
+        "gamelistfilename",
+        "Game list export filename.\n(default depends on frontend)", "FILENAME",
+        "");
     QCommandLineOption refreshOption("refresh", "Same as '--cache refresh'.");
     QCommandLineOption startatOption(
         "startat",
@@ -250,6 +254,7 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
     parser->addOption(flagsOption);
     parser->addOption(fOption);
     parser->addOption(gOption);
+    parser->addOption(gamelistfilenameOption);
     parser->addHelpOption();
     parser->addOption(hintOption);
     parser->addOption(includefromOption);

--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -397,7 +397,8 @@ QStringList EmulationStation::createEsVariantXml(const GameEntry &entry) {
 bool EmulationStation::canSkip() { return true; }
 
 QString EmulationStation::getGameListFileName() {
-    return QString("gamelist.xml");
+    return config->gameListFilename.isEmpty() ? QString("gamelist.xml")
+                                              : config->gameListFilename;
 }
 
 QString EmulationStation::getInputFolder() {

--- a/src/pegasus.cpp
+++ b/src/pegasus.cpp
@@ -498,7 +498,8 @@ void Pegasus::assembleList(QString &finalOutput,
 bool Pegasus::canSkip() { return true; }
 
 QString Pegasus::getGameListFileName() {
-    return QString("metadata.pegasus.txt");
+    return config->gameListFilename.isEmpty() ? QString("metadata.pegasus.txt")
+                                              : config->gameListFilename;
 }
 
 QString Pegasus::getInputFolder() {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -194,6 +194,10 @@ void RuntimeCfg::applyConfigIni(CfgType type, QSettings *settings,
                 config->extensions = v;
                 continue;
             }
+            if (k == "gameListFilename") {
+                config->gameListFilename = v;
+                continue;
+            }
             if (k == "gameListFolder") {
                 config->gameListFolder = (type == CfgType::MAIN ||
                                           type == CfgType::FRONTEND /* #68 */)
@@ -622,6 +626,9 @@ void RuntimeCfg::applyCli(bool &inputFolderSet, bool &gameListFolderSet,
             Cli::cacheReportMissingUsage();
             exit(0);
         }
+    }
+    if (parser->isSet("gamelistfilename")) {
+        config->gameListFilename = parser->value("gamelistfilename");
     }
     if (parser->isSet("startat")) {
         config->startAt = parser->value("startat");

--- a/src/settings.h
+++ b/src/settings.h
@@ -57,6 +57,7 @@ struct Settings {
     QString igdbToken = "";
     QString inputFolder = "";
     QString gameListFolder = "";
+    QString gameListFilename = "";
     QString mediaFolder = "";
     // Next two only relevant for EmulationStation/ES-DE
     bool mediaFolderHidden = false; // EmulationStation only
@@ -208,6 +209,7 @@ private:
         {"forceFilename",           QPair<QString, int>("bool", CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"frontend",                QPair<QString, int>("str",  CfgType::MAIN                                                            )},
         {"gameListBackup",          QPair<QString, int>("bool", CfgType::MAIN |                     CfgType::FRONTEND                    )},
+        {"gameListFilename",        QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"gameListFolder",          QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"gameListVariants",        QPair<QString, int>("str",                                      CfgType::FRONTEND                    )},
         {"hints",                   QPair<QString, int>("bool", CfgType::MAIN                                                            )},

--- a/src/settings.h
+++ b/src/settings.h
@@ -209,7 +209,7 @@ private:
         {"forceFilename",           QPair<QString, int>("bool", CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"frontend",                QPair<QString, int>("str",  CfgType::MAIN                                                            )},
         {"gameListBackup",          QPair<QString, int>("bool", CfgType::MAIN |                     CfgType::FRONTEND                    )},
-        {"gameListFilename",        QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
+        {"gameListFilename",        QPair<QString, int>("str",                                      CfgType::FRONTEND                    )},
         {"gameListFolder",          QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"gameListVariants",        QPair<QString, int>("str",                                      CfgType::FRONTEND                    )},
         {"hints",                   QPair<QString, int>("bool", CfgType::MAIN                                                            )},


### PR DESCRIPTION
### Description
This pull request introduces an enhancement to the Skyscraper tool by adding a new parameter called `gameListFilename` in the `config.ini` file. Additionally, a corresponding command-line interface (CLI) option named `gamelistfilename` has been implemented.

With this change, users can specify a custom filename for the gamelist, which is particularly useful for those using EmuDeck with the Pegasus frontend. This enhancement helps prevent duplicate entries in Pegasus by allowing users to generate a `metadata.txt` file instead of the default `metadata.pegasus.txt`.

### Related Issue
This pull request addresses issue #103 .

### Changes
- Added `gameListFilename` parameter to `config.ini` for custom gamelist filename specification.
- Introduced CLI option `gamelistfilename` to allow users to set the filename directly from the command line.
