### PR TITLE
Feature: enables cache commands for all platforms by default

### DIFF
--- a/docs/CLIHELP.md
+++ b/docs/CLIHELP.md
@@ -279,6 +279,8 @@ This is a powerful option that allows you to purge the requested resources from 
 
 You can purge _all_ resources from the cache for the chosen platform using the keyword `all`.
 
+If no platform is specified, the `purge:all` operation will apply to all existing platforms stored in the cache. In this scenario, any platform-specific configurations defined in the config.ini file will be disregarded.
+
 You can purge specific resources from a certain module with `m=<MODULE>` or of a certain type with `t=<TYPE>` or a combination of the two separated by a `,`.
 
 Supported modules can be seen under `-s` when using the `--help` option. Supported types are: `title`, `platform`, `description`, `publisher`, `developer`, `ages`, `tags`, `rating`, `releasedate`, `cover`, `screenshot`, `wheel`, `marquee`, `video`.
@@ -294,6 +296,7 @@ Skyscraper -p snes --cache purge:all
 Skyscraper -p snes --cache purge:m=thegamesdb
 Skyscraper -p snes --cache purge:t=cover
 Skyscraper -p snes --cache purge:m=thegamesdb,t=cover
+Skyscraper --cache purge:all
 ```
 
 #### --cache refresh
@@ -319,6 +322,8 @@ You can use any of the following:
 -   `type1`,`type2`,`type3`,...:
 
 Supported resource types are: `title`, `platform`, `description`, `publisher`, `developer`, `ages`, `tags`, `rating`, `releasedate`, `cover`, `screenshot`, `wheel`, `marquee`, `video`.
+
+If no platform is specified, reports will be generated for all existing platforms stored in the cache. In this scenario, any platform-specific configurations defined in the config.ini file will be disregarded.
 
 !!! tip
 
@@ -347,6 +352,8 @@ Skyscraper -p snes --cache show
 
 You can purge all resources that don't have any connection to your current romset for the selected platform by using the `vacuum` command. This is extremely useful if you've removed a bunch of roms from your collection and you wish to purge any cached data you don't need anymore.
 
+If no platform is specified, the vacuum operation will apply to all existing platforms stored in the cache. In this scenario, any platform-specific configurations defined in the config.ini file will be disregarded.
+
 !!! danger "Possible dangerous command"
 
     Vacuuming the cache cannot be undone, so please consider making a backup.
@@ -360,6 +367,8 @@ Skyscraper -p snes --cache vacuum
 #### --cache validate
 
 This will test the integrity of the resource cache connected to the chosen platform. It will remove / clean out any stray files that aren't connected to an entry in the cache and vice versa. It's not really necessary to use this option unless you have manually deleted any of the cached files or entries in the `db.xml` file connected to the platform.
+
+If no platform is specified, the validate operation will apply to all existing platforms stored in the cache. In this scenario, any platform-specific configurations defined in the config.ini file will be disregarded.
 
 !!! note
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -37,6 +37,8 @@
 #include <QSharedPointer>
 #include <QString>
 
+class Skyscraper;
+
 struct Resource {
     QString cacheId = "";
     int version = 1;
@@ -69,6 +71,12 @@ struct ResCounts {
 class Cache {
 public:
     Cache(const QString &cacheFolder);
+
+    static bool isCommandValidOnAllPlatform(const QString &command);
+    static void purgeAllPlatform(Settings config, Skyscraper *app);
+    static void reportAllPlatform(Settings config, Skyscraper *app);
+    static void vacuumAllPlatform(Settings config, Skyscraper *app);
+    static void validateAllPlatform(Settings config, Skyscraper *app);
 
     static const QStringList getAllResourceTypes();
     bool createFolders(const QString &scraper);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,8 @@ int main(int argc, char *argv[]) {
     if (argc <= 1 || parser.isSet("help") || parser.isSet("h")) {
         parser.showHelp();
     } else {
-        x = new Skyscraper(parser, currentDir);
+        x = new Skyscraper(currentDir);
+        x->loadConfig(parser);
         QObject::connect(x, &Skyscraper::finished, &app,
                             &QCoreApplication::quit);
         QTimer::singleShot(0, x, SLOT(run()));

--- a/src/settings.h
+++ b/src/settings.h
@@ -181,6 +181,7 @@ private:
     void setFlag(const QString flag);
     QSet<QString> getKeys(CfgType type);
     QStringList parseFlags();
+    void reportInvalidPlatform();
 
     Settings *config;
     const QCommandLineParser *parser;

--- a/src/skyscraper.h
+++ b/src/skyscraper.h
@@ -44,12 +44,18 @@ class Skyscraper : public QObject {
     Q_OBJECT
 
 public:
-    Skyscraper(const QCommandLineParser &parser, const QString &currentDir);
+    Skyscraper(const QString &currentDir);
     ~Skyscraper();
     QSharedPointer<Queue> queue;
     QSharedPointer<NetManager> manager;
     enum OpMode { SINGLE, NO_INTR, CACHE_EDIT, CACHE_EDIT_DISMISS, THREADED };
     int state = SINGLE;
+
+    void loadConfig(const QCommandLineParser &parser);
+    const inline QString getPlatformFileExtensions() {
+        return Platform::get().getFormats(config.platform, config.extensions,
+                                          config.addExtensions);
+    }
 
 public slots:
     void run();
@@ -64,7 +70,6 @@ private slots:
 
 private:
     Settings config;
-    void loadConfig(const QCommandLineParser &parser);
     QString secsToString(const int &seconds);
     void checkForFolder(QDir &folder, bool create = true);
     void showHint();
@@ -80,10 +85,6 @@ private:
     void setLangPrios();
     QString normalizePath(QFileInfo fileInfo);
     // void migrate(QString filename);
-    const inline QString platformFileExtensions() {
-        return Platform::get().getFormats(config.platform, config.extensions,
-                                          config.addExtensions);
-    }
     void setFolder(const bool doCacheScraping, QString &outFolder,
                    const bool createMissingFolder = true);
 


### PR DESCRIPTION
### Overview
This pull request addresses #65 by allowing cache commands to be applied to all platforms present in the cache when no specific platform is specified. This enhancement simplifies the usage of cache commands, eliminating the need for users to specify each platform individually.

### Changes Made
- Implemented functionality to apply the `--cache` command to all platforms in the cache if no platform is set.
- Platforms are identified through their corresponding directories in the cache.
- The following cache options are now supported for application across all platforms: `purge:all`, `report-missing`, `vacuum`, `validate`.
- **Note:** This command does not consider platform-specific configurations in the `config.ini` file, as the config file is not reloaded for each platform.

### Usage Example
To vacuum the cache for all platforms, users can now run: `Skyscraper --cache vacuum`