### PR TITLE
Merge aliases in Pegasus metadata files

### DIFF
--- a/src/pegasus.h
+++ b/src/pegasus.h
@@ -28,6 +28,8 @@
 
 #include "abstractfrontend.h"
 
+#include <QMap>
+
 class Pegasus : public AbstractFrontend {
     Q_OBJECT
 
@@ -55,7 +57,7 @@ private:
     QString fromPreservedHeader(const QString &key, const QString &suggested);
     void removePreservedHeader(const QString &key);
     QString toPegasusFormat(const QString &key, const QString &value);
-    QList<QPair<QString, QString>> headerPairs;
+    QMap<QString, QString> headerPairs;
     QString tab = "  ";
 };
 

--- a/src/pegasus.h
+++ b/src/pegasus.h
@@ -57,6 +57,8 @@ private:
     QString fromPreservedHeader(const QString &key, const QString &suggested);
     void removePreservedHeader(const QString &key);
     QString toPegasusFormat(const QString &key, const QString &value);
+    QString addMediaFile(const QString &asset, bool useRelativePath,
+                         QString &mediaFile);
     QMap<QString, QString> headerPairs;
     QString tab = "  ";
 };


### PR DESCRIPTION
### Description
This pull request addresses the enhancement proposed in issue #102, focusing on the handling of `command`/`launch` and `workdir`/`cwd` aliases within the Pegasus metadata gamelist.

### Changes Made
- Replaced `QList<QPair<QString, QString>>` headerPairs with a `QMap` to prevent duplicate keys.
- Overhauled the `Pegasus::loadOldGameList()` function for improved performance and clarity.
- Refactored the `Pegasus::loadOldGameList()` function to convert the `command` key to `launch`.
- Applied the same conversion logic for the `workdir` and `cwd` keys.
- Prefer the `launch`  key entry to `command` in the Pegasus metadata gamelist, in accordance with the [Pegasus documentation](https://pegasus-frontend.org/docs/user-guide/meta-files/).

### Benefits
These changes ensure that the metadata remains clean and consistent, effectively preventing duplicate entries in the Pegasus metadata gamelist.

Thank you for considering this pull request!
