### PR TITLE
fix(pegasus): correct relative media paths

### DIFF
--- a/src/pegasus.cpp
+++ b/src/pegasus.cpp
@@ -361,7 +361,7 @@ void Pegasus::assembleList(QString &finalOutput,
 QString Pegasus::addMediaFile(const QString &asset, bool useRelativePath,
                               QString &mediaFile) {
     return toPegasusFormat(
-        asset, (useRelativePath ? mediaFile.replace(config->inputFolder, ".")
+        asset, (useRelativePath ? mediaFile.replace(config->mediaFolder, ".")
                                 : mediaFile));
 }
 


### PR DESCRIPTION
It looks like there was an issue when generating relative media paths for Pegasus. It was using the `inputFolder` config value rather than `mediaFolder`. As a result, if your media dir wasn't nested in your ROM input dir you'd end up with absolute paths for media files no matter `relativePaths` was set to.