### PR TITLE
Minor enhancements and edge-case fixes

### DIFF
--- a/src/abstractscraper.cpp
+++ b/src/abstractscraper.cpp
@@ -684,7 +684,7 @@ void AbstractScraper::runPasses(QList<GameEntry> &gameEntries,
             }
             if (!candidates.empty()) {
                 candidates.sort(Qt::CaseInsensitive);
-                QString pad1 = candidates.length() > 3 ? "\n  " : " ";
+                QString pad1 = candidates.length() > 3 ? "\n  " : "";
                 QString pad2 = candidates.length() > 3 ? "\n  " : ", ";
                 debug.append(QString("Candidates: ") + pad1 +
                              candidates.join(pad2) + "\n");

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -272,8 +272,8 @@ void Cli::createParser(QCommandLineParser *parser, QString platforms) {
     parser->addOption(uOption);
     parser->addOption(verbosityOption);
     parser->addVersionOption();
-    parser->addPositionalArgument(
-        "romfile", "Specific ROM to scrape, optionally.", "[<romfile>]");
+    parser->addPositionalArgument("romfile(s)", "Specific ROM(s) to scrape",
+                                  "[<romfile> [<romfile> [<romfile> ... ]]]");
 }
 
 void Cli::subCommandUsage(const QString subCmd) {

--- a/src/compositor.h
+++ b/src/compositor.h
@@ -38,7 +38,8 @@ class Compositor : public QObject {
 
 public:
     Compositor(Settings *config);
-    bool processXml();
+    static bool preCheckArtworkXml(const QString &artworkXml);
+    void processXml();
     void saveAll(GameEntry &game, QString completeBaseName,
                  bool isBatocera = false);
     QString getSubpath(const QString &absPath);

--- a/src/nametools.cpp
+++ b/src/nametools.cpp
@@ -279,6 +279,8 @@ int NameTools::getNumeral(const QString baseName) {
         QString roman = match.captured(1);
         numeral =
             arabicRomanNumerals().key(roman, QString::number(numeral)).toInt();
+        // 'Mega Man V MSU-1' (roman number wins)
+        return numeral;
     }
 
     // Check for european digits

--- a/src/scraperworker.cpp
+++ b/src/scraperworker.cpp
@@ -104,12 +104,7 @@ void ScraperWorker::run() {
     platformOrig = config.platform;
 
     Compositor compositor(&config);
-    if (!compositor.processXml()) {
-        printf("Something went wrong when parsing artwork xml from '%s', "
-               "please check the file for errors. Now exiting...\n",
-               config.artworkConfig.toStdString().c_str());
-        exit(1);
-    }
+    compositor.processXml();
 
     while (queue->hasEntry()) {
         // takeEntry() also unlocks the mutex that was locked in hasEntry()
@@ -258,9 +253,18 @@ void ScraperWorker::run() {
         game.parNotes = NameTools::getUniqueNotes(game.parNotes, '(');
 
         if (!game.found) {
+            QString hint =
+                gameEntries.length() == 0
+                    ? " :("
+                    : QString(", but %1 candidate%1: Use --verbosity 3 or "
+                              "--flags interactive or --query '...' or set an "
+                              "alias (aliasMap.csv). =8^)")
+                          .arg(gameEntries.length() == 1 ? "" : "s")
+                          .arg(gameEntries.length());
             output.append(
-                QString("\033[1;33m---- Game '%1' not found :( ----\033[0m\n\n")
-                    .arg(info.completeBaseName()));
+                QString("\033[1;33m---- Game '%1' not found%2 ----\033[0m\n\n")
+                    .arg(info.completeBaseName())
+                    .arg(hint));
             game.resetMedia();
             if (!forceEnd) {
                 forceEnd = limitReached(output);

--- a/src/strtools.cpp
+++ b/src/strtools.cpp
@@ -290,7 +290,7 @@ QString StrTools::getVersionHeader() {
         dashesString = dashesString % "-";
     }
 
-    return QString("\033[1;34m" % dashesString % "\033[0m\n\033[1;33m" %
+    return QString("\033[1;34m" % dashesString % "\033[0m\n\033[1m" %
                    headerString % "\033[0m\n\033[1;34m" % dashesString %
                    "\033[0m\n");
 }
@@ -364,7 +364,7 @@ QString StrTools::tidyText(QString text, bool ignoreBangs) {
     int ctr = 0;
     int tmpCtr = -1;
     bool itemize = false;
-    QRegularExpression re("^[\\*●]\\s+");
+    QRegularExpression re("^[\\*●•]\\s+");
     QString tmpPiggy;
     for (auto l : pars) {
         ctr++;

--- a/src/xmlreader.cpp
+++ b/src/xmlreader.cpp
@@ -45,8 +45,7 @@ bool XmlReader::setFile(QString filename) {
 #if QT_VERSION < 0x060800
         if (setContent(f.readAll(), false, &eMsg, &eLine)) {
 #else
-        // FIXME: compile against 6.8 or later
-        QDomDocument::ParseResult p = QDomDocument::setContent(f.readAll());
+        QDomDocument::ParseResult p = setContent(f.readAll());
         eMsg = p.errorMessage;
         eLine = p.errorLine;
         if (p) {

--- a/test/nametools/test_nametools.cpp
+++ b/test/nametools/test_nametools.cpp
@@ -67,6 +67,7 @@ private slots:
         }
         QCOMPARE(NameTools::getNumeral("Blarf 0"), 1);
         QCOMPARE(NameTools::getNumeral("Blarf -1"), 1);
+        QCOMPARE(NameTools::getNumeral("Mega Man V MSU-1"), 5);
     }
 
     void testGetSqrNotes() {

--- a/test/strtools/test_strtools.cpp
+++ b/test/strtools/test_strtools.cpp
@@ -150,7 +150,6 @@ private slots:
             QCOMPARE(StrTools::conformAges(i.key()), i.value());
         }
         QCOMPARE(StrTools::conformAges("23"), "23");
-        QCOMPARE(StrTools::conformAges(""), "");
     }
 
     void testConformPlayers() {


### PR DESCRIPTION
- fix edge case when romname contains roman and european numbers
- remove empty gamelist media subfolders after creating gamelist
- provide hint when game is 'almost' matched on how to support the matching
- provide hint/warning when exprected file is missing to complete artwork as defined in artwork XML file
- check well-formedness of artwork XML before entering threading
- test: remove surplus test
- 'Skyscraper -h' help texts adjusted