### PR TITLE
Adjust artwork and filetypes for batocera

### DIFF
--- a/batocera-artwork.xml
+++ b/batocera-artwork.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Just the screenshot without any decorations or scaling -->
 <artwork>
+  <!-- copies the resourcetypes without any artwork applied to the respective mediafolder -->
   <output type="screenshot"/>
+  <output type="marquee" resource="wheel" />
+  <output type="cover" />
+  <output type="wheel" />
 </artwork>

--- a/config.ini.example
+++ b/config.ini.example
@@ -194,3 +194,8 @@ cacheScreenshots="false"
 
 [batocera]
 artworkXml="batocera-artwork.xml"
+;gameListFolder="~/path/to/mounted/userdata/roms"
+; relative to gameListFolder
+inputFolder="."
+mediaFolder="."
+;videos="true"

--- a/docs/CONFIGINI.md
+++ b/docs/CONFIGINI.md
@@ -103,7 +103,7 @@ This is an alphabetical index of all configuration options their usage level and
 | [includePattern](CONFIGINI.md#includepattern)               | Advanced       |    Y     |       Y        |       Y        |               |
 | [innerBracketsReplace](CONFIGINI.md#innerbracketsreplace)   | Expert         |    Y     |                |                |               |
 | [innerParenthesesReplace](CONFIGINI.md#innerparenthesesreplace) | Expert     |  Y       |                |                |               |
-| [inputFolder](CONFIGINI.md#inputfolder)                     | Advanced       |    Y     |       Y        |                |               |
+| [inputFolder](CONFIGINI.md#inputfolder)                     | Advanced       |    Y     |       Y        |       Y        |               |
 | [interactive](CONFIGINI.md#interactive)                     | Basic          |    Y     |       Y        |                |       Y       |
 | [jpgQuality](CONFIGINI.md#jpgquality)                       | Advanced       |    Y     |       Y        |                |       Y       |
 | [keepDiscInfo](CONFIGINI.md#keepdiscinfo)                   | Expert         |    Y     |       Y        |                |               |
@@ -150,10 +150,12 @@ Sets the rom input folder. By default Skyscraper will look for roms in the `/hom
 
 !!! note
 
-    If this is set in the `[main]` section it will automatically add `/<PLATFORM>` to the end of the path. If you want better control consider adding it to a `[<PLATFORM>]` section instead where it will be used as is.
+    If this is set in the `[main]` or `[<FRONTEND>]` section it will automatically add `/<PLATFORM>` to the end of the path. If you want better control consider adding it to a `[<PLATFORM>]` section instead where it will be used as is.
 
 Default value: `/home/<USER>/RetroPie/roms/<PLATFORM>`  
-Allowed in sections: `[main]`, `[<PLATFORM>]`
+Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
+
+The default is valid for the most frontends, very few [frontends](FRONTENDS.md) do use a different default value.
 
 ---
 
@@ -167,6 +169,8 @@ Sets the game list export folder. By default Skyscraper exports the game list to
 
 Default value: `/home/<USER>/RetroPie/roms/<PLATFORM>`  
 Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
+
+The default is valid for the most frontends, very few [frontends](FRONTENDS.md) do use a different default value.
 
 ---
 
@@ -200,6 +204,8 @@ Read more about the [artwork compositing](ARTWORK.md).
 
 Default value: `/home/<USER>/RetroPie/roms/<PLATFORM>/media`  
 Allowed in sections: `[main]`, `[<PLATFORM>]`, `[<FRONTEND>]`
+
+The default is valid for the most frontends, very few [frontends](FRONTENDS.md) do use a different default value.
 
 ---
 

--- a/docs/FRONTENDS.md
+++ b/docs/FRONTENDS.md
@@ -2,11 +2,11 @@
 
 When generating a game list with Skyscraper you have the option of generating it for several different frontends. A frontend is the graphical interface that lists and launches your games.
 
+!!! danger inline end "Backup Any Manual Changes of Your Gamelists"
+
+    Skyscraper will overwrite your game list (obviously). So if you have spend a lot of time hand-crafting metadata in a game list for any frontend, please remember to create a backup before overwriting it with Skyscraper. You can also tell Skyscraper to auto-backup old game lists prior to overwriting them. Read more about the [`gameListBackup` config option](CONFIGINI.md#gamelistbackup).
+
 Setting a frontend when generating a game list is done by setting the `-f <FRONTEND>` command-line parameter as explained [in the commandline documentation](CLIHELP.md#-f-frontend) or by setting it in `/home/<USER>/.skyscraper/config.ini` as explained [config file documentation](CONFIGINI.md#frontend). Use for the `<FRONTEND>` value the frontend name all lowercase and with alphabetical characters only: `emulationstation`, `esde`, `pegasus`, `retrobat`, `attractmode`. Some frontends have further options that are either optional or required. Check the frontend sections below for more information on this.
-
-!!! warning
-
-    Skyscraper will overwrite your game list (obviously). So if you have spend a lot of time hand-crafting metadata in a game list for any frontend, please remember to create a backup before overwriting it with Skyscraper. You can also tell Skyscraper to auto-backup old game lists prior to overwriting them. Read more about the [`gamelistbackup` config option](CONFIGINI.md#gamelistbackup).
 
 When generating a game list for any frontend, Skyscraper will try to preserve certain metadata. Check the frontend sections below for more information on what metadata is preserved per frontend.
 
@@ -21,7 +21,7 @@ This is the default frontend used when generating a game list with Skyscraper. I
 
 Skyscraper will preserve the following metadata when re-generating a game list for EmulationStation: `favorite`, `hidden`, `kidgame`, `lastplayed`, `playcount`, `sortname`. Also existing `<folder/>` elements of a gamelist file will be preserved. The user editable sub-XML elements for a folder are listed in the [`Metadata.cpp` of EmulationStation](https://github.com/RetroPie/EmulationStation/blob/01de7618d0d248fa2ff1eacde09a20d9d2af5f10/es-app/src/MetaData.cpp#L30).
 
-!!! warning
+!!! warning "Folder Data is Not Cached"
 
     Folder data is not cached by Skyscraper, thus if you delete your `gamelist.xml`, Skyscraper can not restore the edited folder elements from cache.
 
@@ -124,7 +124,7 @@ This is the complete set of scraping binary data supported by Skyscraper:
 
 | Batocera Gamelist XML-Element | Skyscraper support |
 | :---------------------------- | :----------------: |
-| boxart                        |         ✓          |
+| thumbnail (cover)             |         ✓          |
 | fanart                        |         ✓          |
 | image (in game Screenshot)    |         ✓          |
 | manual                        |         ✓          |
@@ -139,13 +139,17 @@ every `<PLATFORM>` you scrape.
 -   Default game list filename: `gamelist.xml`
 -   Default media file location: `/userdata/roms/<PLATFORM>/{images,videos,manuals}`
 
+If you set a game list location and do not specifiy the ROM folder (input
+folder) and media folder, then these are set relatively to the game list folder.
+
 #### Metadata preservation
 
-These extra elements are preserved.
+These extra elements are preserved when they are present in the Gamelist file.
 
 | Batocera Gamelist XML-Element | When present in Gamelist  |
 | :---------------------------- | :-----------------------: |
 | `bezel`                       | Preserved                 |
+| `boxart`                      | Preserved                 |
 | `boxback`                     | Preserved                 |
 | `cartridge`                   | Preserved                 |
 | `magazine`                    | Preserved                 |
@@ -155,7 +159,7 @@ These extra elements are preserved.
 | `thumbnail`                   | Preserved                 |
 | `titleshot`                   | Preserved                 |
 
-Also all other non scrapable elements are preserved (Batocera EmulationStation
+Also, all other non scrapable elements are preserved (Batocera EmulationStation
 adds those on occasion) like: `cheevosHash`, `cheevosId`, `scrap`, ...
 
 #### Usage of Skyscraper for Batocera
@@ -178,7 +182,7 @@ Windows desktop users can use SMB shares and can adapt the following steps.
 1. Mount the root folder of Batocera in your Desktop system. Let the mountpoint
    be `/home/mylogin/bato_sshfs` in this example:
    ```bash
-   mount -t sshfs root@<batocera-IP-address>:/ /home/mylogin/bato_sshfs
+   mount -t sshfs root@batocera:/ /home/mylogin/bato_sshfs
    ```
 2. Change to the platform folder (in this case `snes`) you want to scrape:
    ```bash
@@ -193,7 +197,24 @@ Windows desktop users can use SMB shares and can adapt the following steps.
    You can also set the values for [input-](CONFIGINI.md#inputfolder) (`-i`),
    [gamelist-](CONFIGINI.md#gamelistfolder) (`-g`) und
    [media-folder](CONFIGINI.md#mediafolder) (`-o`) permanently in the Skyscraper
-   config file.
+   config file. You can find a sample configuration at the `[batocera]` section
+   (at the end of `config.ini.example`):
+   ```ini
+   [batocera]
+   artworkXml="batocera-artwork.xml"
+   gameListFolder="~/bato_sshfs/userdata/roms"
+   ; relative to gameListFolder
+   inputFolder="."
+   mediaFolder="."
+   ;videos="true"
+   ```
+   With this addition the Skyscraper invocation is reduced to:
+   ```bash
+   Skyscraper -f batocera -p <platform>
+   ```
+   You may also set the default [frontend in the
+   configuration](CONFIGINI.md#frontend), then you can even drop the `-f` CLI
+   parameter.
 4. Afterwards run the gamelist creation and media file deployment from
    cache:
    ```bash
@@ -220,7 +241,7 @@ Windows desktop users can use SMB shares and can adapt the following steps.
     of. Also you will have to add your credentials for Screenscraper for example in
     the [config file of Skyscraper](CONFIGINI.md#usercreds).
 
-For general advise on SSH usage see the [Batocera
+For general advise on SSH usage and the default password see the [Batocera
 documentation](https://wiki.batocera.org/security).
 
 ### Attract-Mode

--- a/docs/PATHHANDLING.md
+++ b/docs/PATHHANDLING.md
@@ -1,5 +1,12 @@
 ## Path Logic in Skyscraper
 
+!!! tip inline end "Absolute Paths"
+
+    You may use `~/` at the beginning of the path. This will be replaced with
+    the current [home directory](https://doc.qt.io/qt-6/qdir.html#homePath)
+    specific to the OS platform. The notation `~account/some/path` is not
+    supported.
+
 This page describes how Skyscraper processes the different paths and especially
 how the absolute path is calculated when a you provide a relative path.
 
@@ -66,12 +73,12 @@ error message.
 
 If you define a relative path Gamelist folder either via `-g` or via
 `gameListFolder=` (INI-file) and are using a frontend for EmulationStation (or
-any other frontend, which is _not_ Pegasus) then the configuration for input
-folder _must_ be provided absolute and can not be relative. In turn, the media
-folder, if it is a relative path, is then assumed to be relative to the input
-folder.
+any other frontend, which is _neither_ Pegasus _nor_ Batocera) then the
+configuration for input folder _must_ be provided absolute and can not be
+relative. In turn, the media folder, if it is a relative path, is then assumed
+to be relative to the input folder.
 
-However, if you selected the Pegasus frontend then the input folder may be
+However, if you selected the Pegasus or Batocera frontend then the input folder may be
 relative. The input folder and media folder, when relative, are then interpreted
 by Skyscraper to be relative to the game list folder.
 

--- a/src/attractmode.cpp
+++ b/src/attractmode.cpp
@@ -321,7 +321,7 @@ QString AttractMode::getMediaTypeFolder(QString type, bool detectVideoPath) {
         while (!emulatorFile.atEnd()) {
             QByteArray line = emulatorFile.readLine();
             line = line.trimmed();
-            line.replace("~", QDir::homePath().toUtf8());
+            line.replace("~/", QDir::homePath().toUtf8() + "/");
             line.replace("$HOME", QDir::homePath().toUtf8());
             QString lookFor = "artwork";
             if (line.left(lookFor.length()) == lookFor) {

--- a/src/batocera.h
+++ b/src/batocera.h
@@ -69,14 +69,14 @@ private:
     static QPair<QString, QString> getFilenameParams(QString k) {
         QMap<QString, QPair<QString, QString>> cacheResFn = {
             // key: "binary type in cache", value: <"-postfix", ".ext">
-            {"cover", QPair<QString, QString>("boxart", "jpg")},
+            {"cover", QPair<QString, QString>("thumb", "jpg")},
             {"fanart", QPair<QString, QString>("fanart", "jpg")},
             {"manual", QPair<QString, QString>("manual", "pdf")},
             {"marquee", QPair<QString, QString>("marquee", "jpg")},
             {"screenshot", QPair<QString, QString>("image", "jpg")},
-            // 'texture' not in Bato
             {"video", QPair<QString, QString>("video", "mp4")},
-            {"wheel", QPair<QString, QString>("wheel", "jpg")},
+            {"wheel", QPair<QString, QString>("wheel", "png")},
+            // 'texture' not in Bato
         };
         return cacheResFn[k];
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -369,3 +369,12 @@ QString Config::lexicallyNormalPath(const QString &pathWithDots) {
         std::filesystem::path(pathWithDots.toStdString()).lexically_normal();
     return QString(result.string().c_str());
 }
+
+QString &Config::expandHomePath(QString &path) {
+    if (path.startsWith("~/")) {
+        path.remove(0, 1);
+        path = QDir::homePath() % path;
+        // "~account/folder" not supported
+    }
+    return path;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -45,6 +45,7 @@ namespace Config {
     QString makeAbsolutePath(const QString &prePath, QString subPath);
     QString lexicallyRelativePath(const QString &base, const QString &other);
     QString lexicallyNormalPath(const QString &pathWithDots);
+    QString &expandHomePath(QString &path);
 } // namespace Config
 
 #endif // CONFIG_H

--- a/src/emulationstation.cpp
+++ b/src/emulationstation.cpp
@@ -413,7 +413,7 @@ QString EmulationStation::elem(const QString &elem, const QString &data,
 
 QStringList EmulationStation::createEsVariantXml(const GameEntry &entry) {
     QStringList l;
-    bool addEmptyElem = !entry.isFolder;
+    bool addEmptyElem = addEmptyElement() && !entry.isFolder;
     l.append(elem(GameEntry::getTag(GameEntry::Elem::COVER), entry.coverFile,
                   addEmptyElem, true));
     l.append(elem(GameEntry::getTag(GameEntry::Elem::SCREENSHOT),

--- a/src/gameentry.h
+++ b/src/gameentry.h
@@ -58,8 +58,9 @@ public:
 
     enum Format { RETROPIE, ESDE, BATOCERA };
 
-    static const QMap<unsigned char, QString> commonGamelistElems() {
-        return QMap<unsigned char, QString>{
+    static const QMap<unsigned char, QString>
+    commonGamelistElems(bool isBatocera = false) {
+        QMap<unsigned char, QString> m = QMap<unsigned char, QString>{
             /* KEY, "gamelist XML element" */
             {DESCRIPTION, "desc"},
             {DEVELOPER, "developer"},
@@ -67,7 +68,6 @@ public:
             {PLAYERS, "players"},
             {TAGS, "genre"},
             {RELEASEDATE, "releasedate"},
-            {COVER, "thumbnail"}, // Batocera uses "<boxart/>"
             {SCREENSHOT, "image"},
             {VIDEO, "video"},
             {RATING, "rating"},
@@ -79,14 +79,15 @@ public:
             {TITLE, "name"},
             {TEXTURE, "texture"},
             {MANUAL, "manual"},
-            // Batocera only and some ES dialects
+            // Batocera, ES-DE only and some ES dialects
             {FANART, "fanart"}};
+        m.insert(COVER, "thumbnail");
+        (void)isBatocera;
+        return m;
     };
 
     static const QString getTag(GameEntry::Elem e, bool isBatocera = false) {
-        QString elemName = commonGamelistElems()[e];
-        if (isBatocera and e == COVER)
-            elemName = "boxart";
+        QString elemName = commonGamelistElems(isBatocera)[e];
         return elemName;
     };
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -203,13 +203,11 @@ bool Layer::save(QString filename) {
 
     canvas = canvas.convertToFormat(QImage::Format_ARGB6666_Premultiplied);
 
-    if (canvas.isNull())
+    if (canvas.isNull()) {
         return false;
-
-    if (canvas.save(filename)) {
-        return true;
     }
-    return false;
+
+    return canvas.save(filename);
 }
 
 void Layer::colorFromHex(QString color) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -841,8 +841,8 @@ bool RuntimeCfg::validateFrontend(const QString &providedFrontend) {
     return true;
 }
 
-bool RuntimeCfg::validateFileParameter(const QString &param,
-                                       const QString &val) {
+bool RuntimeCfg::validateFileParameter(const QString &param, QString &val) {
+    Config::expandHomePath(val);
     if (QFileInfo(val).isRelative()) {
         printf("Parameter %s must be absolute path, got: %s\nPlease fix!\n",
                param.toStdString().c_str(), val.toStdString().c_str());
@@ -871,6 +871,7 @@ bool RuntimeCfg::scraperAllowedForMatch(const QString &providedScraper,
 }
 
 QString RuntimeCfg::toAbsolutePath(bool isCliOpt, QString optionVal) {
+    Config::expandHomePath(optionVal);
     if (QFileInfo(optionVal).isRelative()) {
         // make absolute
         const QString configIniAbsPath =

--- a/src/settings.h
+++ b/src/settings.h
@@ -187,7 +187,7 @@ private:
     QSet<QString> getKeys(CfgType type);
     QStringList parseFlags();
     void reportInvalidPlatform();
-    bool validateFileParameter(const QString &param, const QString &val);
+    bool validateFileParameter(const QString &param, QString &val);
     bool scraperAllowedForMatch(const QString &providedScraper,
                                 const QString &opt);
     QString toAbsolutePath(bool isCliOpt, QString optionVal);
@@ -232,7 +232,7 @@ private:
         {"includePattern",          QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"innerBracketsReplace",    QPair<QString, int>("str",  CfgType::MAIN                                                            )},
         {"innerParenthesesReplace", QPair<QString, int>("str",  CfgType::MAIN                                                            )},
-        {"inputFolder",             QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM                                        )},
+        {"inputFolder",             QPair<QString, int>("str",  CfgType::MAIN | CfgType::PLATFORM | CfgType::FRONTEND                    )},
         {"interactive",             QPair<QString, int>("bool", CfgType::MAIN | CfgType::PLATFORM |                     CfgType::SCRAPER )},
         {"jpgQuality",              QPair<QString, int>("int",  CfgType::MAIN | CfgType::PLATFORM |                     CfgType::SCRAPER )},        
         {"keepDiscInfo",            QPair<QString, int>("bool", CfgType::MAIN | CfgType::PLATFORM                                        )},

--- a/src/skyscraper.h
+++ b/src/skyscraper.h
@@ -84,6 +84,9 @@ private:
     void setRegionPrios();
     void setLangPrios();
     QString normalizePath(QFileInfo fileInfo);
+    QString &removeSurplusPlatformPath(const QString &platform,
+                                       const QString &lastPath,
+                                       QString &sourcePath);
     // void migrate(QString filename);
     void setFolder(const bool doCacheScraping, QString &outFolder,
                    const bool createMissingFolder = true);

--- a/src/xmlreader.cpp
+++ b/src/xmlreader.cpp
@@ -137,8 +137,9 @@ void XmlReader::addEntries(const QDomNodeList &nodes,
 
             QDomNodeList elems = node.childNodes();
             for (int i = 0; i < elems.length(); i++) {
-                QString k = elems.at(i).toElement().tagName();
-                if (entry.commonGamelistElems().values().contains(k) ||
+                QDomElement glElem = elems.at(i).toElement();
+                QString k = glElem.tagName();
+                if (entry.commonGamelistElems(true).values().contains(k) ||
                     k == "path" ||
                     k == "sortname" /* when reading a non-batocera GL */) {
                     // it is a common/baseline gamelist element: do not keep in
@@ -146,8 +147,7 @@ void XmlReader::addEntries(const QDomNodeList &nodes,
                     continue;
                 }
                 // preserve everything else with attributes "as is"
-                entry.setEsExtra(k, elems.at(i).toElement().text(),
-                                 elems.at(i).toElement().attributes());
+                entry.setEsExtra(k, glElem.text(), glElem.attributes());
             }
         }
         entry.isFolder = isFolder;

--- a/test/settings/test_settings.cpp
+++ b/test/settings/test_settings.cpp
@@ -116,8 +116,18 @@ void TestSettings::testConfigIniPaths() {
     exp =
         Config::makeAbsolutePath(config.gameListFolder, "../../rel/inout-roms");
     QCOMPARE(config.gameListFolder % "/" % config.inputFolder, exp);
+
     exp = Config::makeAbsolutePath(config.gameListFolder, "./rel/media");
     QCOMPARE(config.gameListFolder % config.mediaFolder.replace(".", ""), exp);
+
+    exp = Config::makeAbsolutePath(config.gameListFolder, "./");
+    QCOMPARE(config.gameListFolder, exp);
+
+    exp = Config::makeAbsolutePath(config.gameListFolder, ".");
+    QCOMPARE(config.gameListFolder, exp);
+
+    exp = Config::makeAbsolutePath(config.gameListFolder, "~/dont/change");
+    QCOMPARE("~/dont/change", exp);
 }
 
 void TestSettings::testConfigIniMain() {


### PR DESCRIPTION
- Have wheel transparent when using for marquee.
- Use wheel resource as value for marquee in gamelist
- Use thumbnail xml element for cover display
- Configurable path specifications for batocera and others (e.g., home path)
- Update docs (for batocera frontend)