### PR TITLE
Add M3U extension to default extensions/formats for all platforms

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -144,7 +144,7 @@ QString Platform::getFormats(QString platform, QString extensions,
     }
 
     // default extensions/formats for all
-    QSet<QString> formats({"*.zip", "*.7z", "*.ml"});
+    QSet<QString> formats({"*.zip", "*.7z", "*.ml", "*.m3u"});
     QStringList addExts;
 
 #if QT_VERSION >= 0x050e00


### PR DESCRIPTION
Add M3U extension to default extensions/formats for all platforms

#190 

I looked/searched in other places but did not see where to update it in the docs as suggested. Feel free to update or make changes.