### PR TITLE
add SYSCONFDIR variable to allow FHS-compliant builds

### DIFF
--- a/skyscraper.pro
+++ b/skyscraper.pro
@@ -29,6 +29,12 @@ isEmpty(PREFIX) {
   PREFIX = /usr/local
 }
 
+# System configuration directory
+SYSCONFDIR = $$(SYSCONFDIR)
+isEmpty(SYSCONFDIR) {
+  SYSCONFDIR = $${PREFIX}/etc
+}
+
 unix:target.path=$${PREFIX}/bin
 unix:target.files=Skyscraper Skyscraper.app/Contents/MacOS/Skyscraper
 
@@ -39,25 +45,25 @@ unix:supplementary.files=\
   supplementary/scraperdata/peas_and_idmap_verify.py \
   supplementary/scraperdata/README-Skyscraper-Scripts.md
 
-unix:config.path=$${PREFIX}/etc/skyscraper
+unix:config.path=$${SYSCONFDIR}/skyscraper
 unix:config.files=aliasMap.csv hints.xml mameMap.csv \
   mobygames_platforms.json peas.json platforms_idmap.csv \
   screenscraper_platforms.json tgdb_developers.json \
   tgdb_genres.json tgdb_platforms.json tgdb_publishers.json
 
-unix:examples.path=$${PREFIX}/etc/skyscraper
+unix:examples.path=$${SYSCONFDIR}/skyscraper
 unix:examples.files=config.ini.example README.md artwork.xml \
   artwork.xml.example1 artwork.xml.example2 artwork.xml.example3 \
   artwork.xml.example4 batocera-artwork.xml docs/ARTWORK.md docs/CACHE.md
 
-unix:cacheexamples.path=$${PREFIX}/etc/skyscraper/cache
+unix:cacheexamples.path=$${SYSCONFDIR}/skyscraper/cache
 unix:cacheexamples.files=cache/priorities.xml.example docs/CACHE.md
 
-unix:impexamples.path=$${PREFIX}/etc/skyscraper/import
+unix:impexamples.path=$${SYSCONFDIR}/skyscraper/import
 unix:impexamples.files=docs/IMPORT.md import/definitions.dat.example1 \
   import/definitions.dat.example2
 
-unix:resexamples.path=$${PREFIX}/etc/skyscraper/resources
+unix:resexamples.path=$${SYSCONFDIR}/skyscraper/resources
 unix:resexamples.files=resources/maskexample.png resources/frameexample.png \
   resources/boxfront.png resources/boxside.png resources/scanlines1.png \
   resources/scanlines2.png
@@ -73,6 +79,7 @@ unix:count(dev, 1) {
 }
 DEFINES+=VERSION=\\\"$$VERSION\\\"
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -234,7 +234,7 @@ void Config::setupUserConfig() {
         }
     }
 
-    QString localEtcPath = QString(PREFIX "/etc/skyscraper/");
+    QString localEtcPath = QString(SYSCONFDIR "/skyscraper/");
     if (!QFileInfo::exists(localEtcPath) || isRpInstall) {
         // RetroPie or Windows installation type: handled externally
         return;


### PR DESCRIPTION
This change separates the installation prefix (PREFIX) from the system configuration directory by introducing a new `SYSCONFDIR` variable.

Currently, the `skyscraper.pro` file installs configuration files under `$${PREFIX}/etc/skyscraper`, which can result in non-FHS-compliant paths such as /usr/etc/skyscraper. This makes it hard to package skyscraper for most distros without a patch. By separating the `/etc` installation prefix from the binary prefix we can build an an FHS-compliant build without a patch.

With this change
- `SYSCONFDIR` defaults to `$${PREFIX}/etc`, preserving original behavior for local builds.
- Distributors can override `SYSCONFDIR` to `/etc` (or any other desired path) without modifying the `.pro` file.
- Binaries can still be  installed under `$${PREFIX}/bin` as before.