### PR TITLE
fix SYSCONFDIR testcases

### DIFF
--- a/test/abstractscraper/test_abstractscraper.pro
+++ b/test/abstractscraper/test_abstractscraper.pro
@@ -9,7 +9,9 @@ QMAKE_CXXFLAGS += -std=c++17
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 PREFIX = /usr/local
+SYSCONFDIR = $${PREFIX}/etc
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 include(../../VERSION.ini)
 DEFINES+=TESTING

--- a/test/config/test_config.pro
+++ b/test/config/test_config.pro
@@ -16,7 +16,9 @@ unix {
 }
 
 PREFIX = /usr/local
+SYSCONFDIR = $${PREFIX}/etc
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 include(../../VERSION.ini)
 DEFINES+=VERSION=\\\"$$VERSION\\\"

--- a/test/getsearchnames/test_getsearchnames.pro
+++ b/test/getsearchnames/test_getsearchnames.pro
@@ -8,7 +8,9 @@ QMAKE_CXXFLAGS += -std=c++17
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 PREFIX = /usr/local
+SYSCONFDIR = $${PREFIX}/etc
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 include(../../VERSION.ini)
 DEFINES+=VERSION=\\\"$$VERSION\\\"

--- a/test/pegasus/test_pegasus.pro
+++ b/test/pegasus/test_pegasus.pro
@@ -9,7 +9,9 @@ QMAKE_CXXFLAGS += -std=c++17
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 PREFIX = /usr/local
+SYSCONFDIR = $${PREFIX}/etc
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 include(../../VERSION.ini)
 DEFINES+=TESTING

--- a/test/settings/test_settings.pro
+++ b/test/settings/test_settings.pro
@@ -8,7 +8,9 @@ QMAKE_CXXFLAGS += -std=c++17
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 PREFIX = /usr/local
+SYSCONFDIR = $${PREFIX}/etc
 DEFINES+=PREFIX=\\\"$$PREFIX\\\"
+DEFINES+=SYSCONFDIR=\\\"$$SYSCONFDIR\\\"
 
 include(../../VERSION.ini)
 DEFINES+=VERSION=\\\"$$VERSION\\\"


### PR DESCRIPTION
Fixes `abstractscraper`, `config`, `getsearchnames`, `pegasus`, and `settings` test cases by adding `SYSCONFDIR` introduced by #210.