### PR TITLE
Updated build and added config support to docker scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ platforms_idmap_local.csv
 # VS Code
 *.code-workspace
 .vscode
+
+# docker config
+docker/config.ini

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,9 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 
 # Building skyscraper
-COPY ./* ./
+RUN mkdir -p /opt/skyscraper
+WORKDIR /opt/skyscraper
+COPY . .
 RUN rm -f ./VERSION.ini
 RUN chmod +x update_skyscraper.sh  && ./update_skyscraper.sh
 

--- a/docker/process_dir.sh
+++ b/docker/process_dir.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
 # Usage:
-#   ./process_dir.sh [ROMS_DIR]
+#   ./process_dir.sh [ROMS_DIR] {source1} {source2} ...
 # Example
 #   ./process_dir.sh ~/roms
-#   ./process_dir.sh ~/roms > output.txt
+#   ./process_dir.sh ~/roms screenscraper > output.txt
 #
-# Note: can be use for Emulation Station roms folder, but platform name can be different. ES's genesis is megadrive for skyscraper,
+# Note: can be use for Emulation Station roms folder, but platform name can be different. ES's genesis is megadrive for skyscraper.
+# Defaults to screenscraper and thegamesdb sources if none are specified.
 
 TAG=skyscraper
 
 PLATFORMS=$1/*
+shift
+
+SOURCES=("$@")
+if [ ${#SOURCES[@]} -eq 0 ]; then
+  SOURCES=(screenscraper thegamesdb)
+fi
 
 mkdir cache
 
@@ -23,7 +30,7 @@ for file_name in $PLATFORMS; do
     echo "Processing ${PLATFORM}..."
     echo "Mounting $file_name:./roms/$PLATFORM..."
 
-    for source in "screenscraper" "thegamesdb"; do
+    for source in "${SOURCES[@]}"; do
       echo "Processing $PLATFORM on $source..."
 
       ./scrape.sh $file_name $PLATFORM $source

--- a/docker/save.sh
+++ b/docker/save.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Usage:
-#   ./scrape.sh [ROMS_DIR] [PLATFORM]
+#   ./save.sh [ROMS_DIR] [PLATFORM]
 # Example
-#   ./scrape.sh ./roms/snes snes
+#   ./save.sh ./roms/snes snes
 
 TAG=skyscraper
 
@@ -14,4 +14,4 @@ docker run \
   -v "$ROMS_DIR:/tmp/roms/$PLATFORM" \
   -v "$(pwd)/cache:/tmp/skyscraper_cache" \
   $TAG \
-  -p $PLATFORM -i /tmp/roms/$PLATFORM -d /tmp/skyscraper_cache --flags relative,unattendskip
+  -p $PLATFORM -i /tmp/roms/$PLATFORM -g /tmp/roms/$PLATFORM -o /tmp/roms/$PLATFORM/media -d /tmp/skyscraper_cache --flags relative,unattend

--- a/docker/scrape.sh
+++ b/docker/scrape.sh
@@ -11,8 +11,17 @@ ROMS_DIR=$1
 PLATFORM=$2
 SOURCE=$3
 
-docker run \
-  -v "$ROMS_DIR:/tmp/roms/$PLATFORM" \
-  -v "$(pwd)/cache:/tmp/skyscraper_cache" \
-  $TAG \
-  -p $PLATFORM -s $SOURCE -i /tmp/roms/$PLATFORM -d /tmp/skyscraper_cache
+if [ -f ./config.ini ]; then
+  docker run \
+    -v "$ROMS_DIR:/tmp/roms/$PLATFORM" \
+    -v "$(pwd)/cache:/tmp/skyscraper_cache" \
+    -v "$(pwd)/config.ini:/root/.skyscraper/config.ini" \
+    $TAG \
+    -p $PLATFORM -s $SOURCE -i /tmp/roms/$PLATFORM -d /tmp/skyscraper_cache
+else
+  docker run \
+    -v "$ROMS_DIR:/tmp/roms/$PLATFORM" \
+    -v "$(pwd)/cache:/tmp/skyscraper_cache" \
+    $TAG \
+    -p $PLATFORM -s $SOURCE -i /tmp/roms/$PLATFORM -d /tmp/skyscraper_cache
+fi


### PR DESCRIPTION
Closes #220 by adding a workdir and removing wildcard from COPY command in the Dockerfile. Also adds the optional ability to provide a `config.ini` when running the docker scripts (mainly to give the ability to set scraper credentials if desired).

I also added `-g` and `-o` arguments to the `save.sh` script, since in its current state it was saving the `gamelist.xml` and media to the docker container's storage instead of the mapped volume, and replaced `unattendskip` with `unattend` so that it can be used to update existing gamelists.

Lastly modified the `process_dir.sh` script to optionally allow sources to be specified as additional arguments (falling back to the old defaults of `screenscraper` and `thegamesdb` if not specified).