### PR TITLE
Fix -Werror=format-security build failure on gcc 15 / CachyOS / hardened distros

### DIFF
--- a/src/nocolor.cpp
+++ b/src/nocolor.cpp
@@ -84,7 +84,7 @@ void printVA(int nvargs, const char *fmt, ...) {
                 }
             }
         }
-        printf(fmtPlain.toStdString().c_str());
+        printf("%s", fmtPlain.toStdString().c_str());
     } else {
         va_start(args, fmt);
         vprintf(fmt, args);


### PR DESCRIPTION
## Summary

`src/nocolor.cpp:87` passes a dynamically-constructed string as the format argument to `printf`:

```cpp
printf(fmtPlain.toStdString().c_str());
```

Modern gcc (15.x, shipped by CachyOS and rolling Arch-based distros, also trending into other distros) combined with `-Werror=format-security -D_FORTIFY_SOURCE=3` rejects this as an error:

```
src/nocolor.cpp:87:15: error: format not a string literal and no format arguments [-Werror=format-security]
   87 |         printf(fmtPlain.toStdString().c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
make: *** [Makefile:1479: nocolor.o] Error 1
```

This kills the build on CachyOS / Arch AUR packaging and anywhere `-Werror=format-security` is in the default CFLAGS.

## Fix

Add an explicit `"%s"` format string so `printf` knows the argument is a value, not a format template:

```cpp
printf("%s", fmtPlain.toStdString().c_str());
```

## Impact

- **No functional change.** `printf("%s", s)` produces identical output to `printf(s)` whenever `s` contains no `%` format specifiers. `fmtPlain` here is the color-stripped output of `StrTools::stripColorEscaped()`, which only contains literal text.
- **Security tangentially improved.** If `fmtPlain` ever accidentally ended up containing `%` characters (it currently can't, but defense in depth), the old form would reinterpret them as format specs and read beyond the variadic args; the new form prints them literally.

## Testing

Built against the AUR `skyscraper-git` PKGBUILD on CachyOS (gcc 15.2.1, `-D_FORTIFY_SOURCE=3 -Werror=format-security -flto=auto`). Build succeeds, scraper runs normally.

## Related

This is the one site that breaks builds today; there are a handful of similar `ncprintf(dynamic.toStdString().c_str())` patterns in `main.cpp` and `cache.cpp` that *could* theoretically trip the same warning in the future if `ncprintf` gains a `__attribute__((format(printf,...)))` declaration — not fixing those here to keep the PR minimal, but they'd be good hygiene.