### PR TITLE
fix(config): ensure localEtcPath has a trailing slash for portable binary paths

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -255,6 +255,9 @@ void Config::setupUserConfig() {
                 QString(SYSCONFDIR "/skyscraper/"));
         }
     }
+    if (!localEtcPath.endsWith('/')) {
+        localEtcPath += '/';
+    }
     if (!QFileInfo::exists(localEtcPath) || isRpInstall) {
         if (!isRpInstall) {
             qDebug() << "local install path does not exist" << localEtcPath;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -258,7 +258,7 @@ void Config::setupUserConfig() {
     if (!localEtcPath.endsWith('/')) {
         localEtcPath += '/';
     }
-    if (!QFileInfo::exists(localEtcPath) || isRpInstall) {
+    if (localEtcPath.startsWith(QCoreApplication::applicationDirPath()) || !QFileInfo::exists(localEtcPath) || isRpInstall) {
         if (!isRpInstall) {
             qDebug() << "local install path does not exist" << localEtcPath;
         }


### PR DESCRIPTION
### Summary
When running Skyscraper as a standalone binary in non-standard directories (such as `/path/to/app/bin/Skyscraper`):

1. `QCoreApplication::applicationDirPath()` returns `/path/to/app/bin` (without a trailing slash `/`).
2. `localEtcPath` falls back to `applicationDirPath()`, pointing to `/path/to/app/bin` (which exists on disk).
3. In `copyFile(localEtcPath % src, ...)`, `localEtcPath` (`.../bin`) concatenates directly with `src` (`"ARTWORK.md"`), producing `/path/to/app/binARTWORK.md`.
4. Skyscraper bails out on startup with:
   `Source config file not found '/path/to/app/binARTWORK.md'. Please check setup, bailing out...`

### Solution
Added a trailing slash check for `localEtcPath` in `src/config.cpp` so string concatenation produces valid directory paths (`.../bin/ARTWORK.md`).

---

### Update: Prevent mistaking binary execution directory for etc config source

Furthermore, when `localEtcPath` falls back to `QCoreApplication::applicationDirPath()` (`.../bin`), `QFileInfo::exists(localEtcPath)` evaluates to `true` because the binary folder exists on disk. This causes Skyscraper to mistake its own binary folder for a system `/etc/skyscraper/` configuration directory and attempt to copy non-existent documentation/template files (`ARTWORK.md`).

**Additional Fix**: Added a check in `src/config.cpp` to exit early when `localEtcPath` points to the application binary folder:
```cpp
if (localEtcPath.startsWith(QCoreApplication::applicationDirPath()) || !QFileInfo::exists(localEtcPath) || isRpInstall) {
    return;
}
