### PR TITLE
Fix ArcadeDB scraper: use https baseUrl

### DIFF
--- a/src/arcadedb.cpp
+++ b/src/arcadedb.cpp
@@ -40,7 +40,7 @@ static const QRegularExpression MATCH_COPYRIGHT = QRegularExpression(
 
 ArcadeDB::ArcadeDB(Settings *config, QSharedPointer<NetManager> manager)
     : AbstractScraper(config, manager, MatchType::MATCH_ONE) {
-    baseUrl = "http://adb.arcadeitalia.net";
+    baseUrl = "https://adb.arcadeitalia.net";
 
     searchUrlPre =
         baseUrl +


### PR DESCRIPTION
adb.arcadeitalia.net now 301-redirects `http://` → `https://`. Qt 5's QNetworkAccessManager does not follow redirects by default, so every ArcadeDB query receives the redirect response instead of JSON and all lookups silently report 'not found'.

Fix: bump `baseUrl` to https (all search/media URLs derive from it).

Tested on Qt 5.15 / Linux against a 375-file mame2003-plus set: before the change 0 hits; after, 375/375 matched with cover/screenshot/wheel/marquee all fetched.